### PR TITLE
Added PH Core Encounter profile

### DIFF
--- a/input/fsh/profiles/ph-core-encounter.fsh
+++ b/input/fsh/profiles/ph-core-encounter.fsh
@@ -1,0 +1,6 @@
+Profile: PHCoreEncounter
+Parent: Encounter
+Id: ph-core-encounter
+Title: "PH Core Encounter"
+Description: "This profile sets minimum expectations for an Encounter resource to record, search, and fetch basic encounter information for a patient. It is based on the [FHIR R4 Encounter](https://www.hl7.org/fhir/R4/encounter.html) resource and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Encounter when conforming to this profile. It provides the floor for standards development for specific uses cases in a Philippine context."
+* ^url = "urn://example.com/ph-core/fhir/StructureDefinition/ph-core-encounter"


### PR DESCRIPTION
Added a PH Core Encounter profile.

Note that other than metadata, there is no change from the base FHIR R4 resource. This is because the (extensive) modifications done by the NHDR team were either

* zeroing out fields that should be left in for Core
* modeled incorrectly (e.g., extensions for things that can be handled within the base resource or belong on another resource)
* making existing FHIR Example strength bindings mandatory (probably not correct for any PH use case)

Additional stakeholder input and comparison with US, AU, and other Core Encounter profiles will be needed to make a compelling PH Core profile for this resource.