### PR TITLE
Added a PH Core Observation profile

### DIFF
--- a/input/fsh/profiles/ph-core-observation.fsh
+++ b/input/fsh/profiles/ph-core-observation.fsh
@@ -1,0 +1,9 @@
+Profile: PHCoreObservation
+Parent: Observation
+Id: ph-core-observation
+Title: "PH Core Observation"
+Description: "Measurements and simple assertions made about a patient, device or other subject."
+* ^url = "urn://example.com/ph-core/fhir/StructureDefinition/ph-core-observation"
+
+* subject only Reference(ph-core-patient)
+* encounter only Reference(ph-core-encounter)


### PR DESCRIPTION
Added a PH Core Observation profile.

Note that nearly all the work done by the NHDR team has been removed as not needed for Core use case.

Note that this branch won't pass SUSHI until after the Encounter resource has been added.

Note that US and AU have not made a Core Observation, but have instead jumped straight to specific Observation types such as Vital Signs or Smoking Status.