### PR TITLE
Added a PH Core Procedure profile

### DIFF
--- a/input/fsh/profiles/ph-core-procedure.fsh
+++ b/input/fsh/profiles/ph-core-procedure.fsh
@@ -1,0 +1,9 @@
+Profile: PHCoreProcedure
+Parent: Procedure
+Id: ph-core-procedure
+Title: "PH Core Procedure"
+Description: "An action that is or was performed on or for a patient, practitioner, device, organization, or location."
+* ^url = "urn://example.com/ph-core/fhir/StructureDefinition/ph-core-procedure"
+
+* subject only Reference(PH_Patient)
+* encounter only Reference(PH_Encounter)


### PR DESCRIPTION
Added a PH Core Procedure profile

This is mostly the same as the base Resource, except for pointing to PH Patient and Encounter profiles.

Note that the extensive modifications done by NHDR team for NHDR Procedure profile have mostly been undone for the broader Core use case and/or a lack of supporting content (e.g., IllnessClass extension has no valueSet in NHDR so can't be implemented at Connectathon).