### PR TITLE
Update index.md

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-PH Core is provided in it's initial DRAFT form to support the use of HL7<sup>&reg;</sup> FHIR<sup>&reg;&copy;</sup> in the Philippines context. It sets the minimum expectations on FHIR resources to support conformance and implementation in systems. The FHIR IG for testing purpose only and not suitable for productions systems. 
+PH Core is provided in its initial DRAFT form to support the use of HL7<sup>&reg;</sup> FHIR<sup>&reg;&copy;</sup> in the Philippines context. It sets the minimum expectations on FHIR resources to support conformance and implementation in systems. The FHIR IG for testing purpose only and not suitable for production systems. 
 
 PH Core defines the Data model and RESTful API interactions that set minimum expectations for a system to record, update, search, and retrieve core digital health and administrative information. 
 
@@ -8,7 +8,6 @@ PH Core defines the Data model and RESTful API interactions that set minimum exp
 - Problems / Conditions
 - Medication orders, dispense, administration and usage
 - Immunization
-- Allergies and intolerances
 - Vital signs, and other clinical observations
 
 ### Project Backgrouond

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,68 +1,48 @@
-# PH Core FHIR Implementation Guide
+### Introduction
 
-<p class="dragon">This IG is provided to support a connectathon. It is prototypical, not officially endorsed and may contain any number of errors and omissions. There are no guarantees of quality or stability.</p>
+PH Core is provided in it's initial DRAFT form to support the use of HL7<sup>&reg;</sup> FHIR<sup>&reg;&copy;</sup> in the Philippines context. It sets the minimum expectations on FHIR resources to support conformance and implementation in systems. The FHIR IG for testing purpose only and not suitable for productions systems. 
 
-[PH Core](#to-be-done) is provided to support the use of HL7<sup>&reg;</sup> FHIR<sup>&reg;&copy;</sup> in an Philippine context. It sets the minimum expectations on FHIR resources to support conformance and implementation in systems.
-
-PH Core defines the Data model and RESTful API interactions that set minimum expectations for a system to record, update, search, and retrieve core digital health and administrative information. Applications that conform to PH Core can access the following information about the patient:
+PH Core defines the Data model and RESTful API interactions that set minimum expectations for a system to record, update, search, and retrieve core digital health and administrative information. 
 
 - Basic patient details
 - Problems / Conditions
 - Medication orders, dispense, administration and usage
-- Immunization history
+- Immunization
 - Allergies and intolerances
-- Diagnostic orders, report, and results
 - Vital signs, and other clinical observations
-- Clinical notes & other patient documents
 
-PH Core provides basis for profiles that define the FHIR resources to be supported, and the elements, extensions, vocabularies, and value sets that SHALL be present are identified, and how they are used is defined. It also documents the minimum FHIR RESTful interactions for each resource type to access patient data. PH Core promotes interoperability and adoption through common implementation and SHOULD be built on top of for standards development for specific use cases. There are two different ways to implement PH Core:
-1.  Systems may support only PH Core Profiles to represent digital health information ([Profile Only Support](#to-be-done)).
+### Project Backgrouond
 
-1.  Systems may support both PH Core Profiles and the RESTful interactions defined for a resource ([Profile + Interaction Support]()).
+PH Core is actively being developed by UP Manila SILab, under the guidance of the Phillippines Department of Health, with technical assistance from CSIRO Australia, and input from PHIC NHDR and SILab Community of Practice. 
 
-In this regard it is similar in nature to other international FHIR specifications such as US Core FHIR Implementation Guide.
+The initial draft of IG will be tested in the Connectathon to validate proof of concept and direction settings for the Philippines Core IG development process. 
 
-For a detailed description of these different usages of PH Core, see the [Conformance Requirements](#to-be-done) and [Must Support](#to-be-done) pages.
+### Relationship with other IGs
 
-Below is a diagram showing where PH Core is located in the hierarchy of profiles.
+**PH Core:**
+- defines a set of conformance requirements that enforce a set of ‘minimum requirements’ on the local concepts, specifying rules for the elements, extensions, vocabularies, and value sets, and the RESTful API interactions.
+- for use by the stakeholders in the Philippines when implementing FHIR to provide a common implementation and to be built upon when creating further profiles and implementation guides.
+- conformance may become tied to regulatory and/or contractual agreements in order to necessitate adoption to this more prescriptive specification.
+
+The context of PH Core within the set of FHIR Standards is shown in the diagram below.
 
 {% include layers.svg %}
 
-## Did you find an error?
+### Usage
 
-If it's a specification error please search the issues list in the [Jira issue tracker](#to-be-done) to ensure the error was not already reported. You can use the [Propose-a-change](#to-be-done) option at the bottom of each page of the IG to trigger the creation of a Jira issue.
+PH Core is particularly useful in defining:
 
-If you've found an issue with this repository or it's contents then you please [raise a GitHub issue](https://github.com/UP-Manila-SILab/ph-core/issues/new).
+- A testable level of system conformance
+- Assumed support by client applications
+- The basis of downstream implementation guides
 
-## Contributing to PH Core Development
+Implementation of capabilities defined in PH Core enables specifications, applications and business logic to be developed with confidence.
 
-PH Core R1 is currently in development.
+This document is a working specification that may be directly implemented by FHIR®© system producers.
 
-### 1. Join the PH Core Technical Design Group
+FHIR®© Connectathon events are key to the verification of the guide as being suitable for implementation. This implementation guide will be used as the basis for the Philippines Connectathon events.
 
-See [How to Register - Participant Information](#to-be-done)
-
-### 2. Discuss an issue in chat.fhir.org
-
-If you have a question, feature request, or proposed change, the best place to start is [Zulip](#to-be-done)
-
-stream. If what you want to discuss is specific to the Philippines you can post in the [Philippines stream](#to-be-done)
-
-### 3. Identify future work or raise discussion points
-
-To identify future work or raise discussion points, you can post in the [Philippines stream](#to-be-done) or raise [specification feedback](#to-be-done) through a [Jira issue tracker](#to-be-done).
-
-### 4. Discuss with the team
-
-Once the issue is logged, you should discuss with the team on [chat.fhir.org in the Philippines > PH Core topic](#to-be-done) before attempting to make changes yourself. It's important to coordinate with the other people working on the project.
-
-### 5. Create a pull request
-
-When everyone has agreed on a course of action, IG changes should be submitted as a pull request for review in this repository.
-
-### To be done
-
-There are lots of things that the current PH Core FHIR Implementation workgroup does not have. These things will hopefully be implemented at some point. At that point in time, these links may be maintained to point somewhere. Stay tuned.
+### Dependencies
 
 {% include ip-statements.xhtml %}
 {% include cross-version-analysis.xhtml %}
@@ -71,6 +51,8 @@ There are lots of things that the current PH Core FHIR Implementation workgroup 
 {% include dependency-table-nontech.xhtml %}
 {% include globals-table.xhtml %}
 
-## Acknowledgements
+## Feedback
 
-**This README text is derived from the AU Core FHIR Implementation Guide.**
+Feedback specific to this specification can provided through:
+
+Sending an email to silab.upm@up.edu.ph


### PR DESCRIPTION
Updating Index.MD page, removing content that is not related to PH context and derived from AU.

Removed empty sections and to-be-done headers. Included Relationship with IG using existing content and diagram. Updated Usage and Dependencies. Provide UPM SILab email for feedback unless a form or GIT issue reporting is sorted. 