### PR TITLE
Use Period datatype for occupation length

### DIFF
--- a/input/fsh/extensions/occupation.fsh
+++ b/input/fsh/extensions/occupation.fsh
@@ -11,4 +11,4 @@ Description: "Patient's occupation."
 * extension[occupationClassification].valueCodeableConcept from occupational-classifications (extensible)
 * extension[occupationClassification] ^short = "Occupation Classification"
 * extension[occupationLength].value[x] only integer or Period
-* extension[occupationLength] ^short = "Length in Years"
+* extension[occupationLength] ^short = "Length of time in occupation expressed as a date range or a number of years."


### PR DESCRIPTION
Updated the definition of occupation extension to allow the length to be expressed as a Period (date range) or integer (number of years) following a suggestion at June 2025 Connectathon.