### PR TITLE
Constrained references in PHCoreEncounter

### DIFF
--- a/input/fsh/profiles/ph-core-encounter.fsh
+++ b/input/fsh/profiles/ph-core-encounter.fsh
@@ -3,3 +3,5 @@ Parent: Encounter
 Id: ph-core-encounter
 Title: "PH Core Encounter"
 Description: "This profile sets minimum expectations for an Encounter resource to record, search, and fetch basic encounter information for a patient. It is based on the [FHIR R4 Encounter](https://www.hl7.org/fhir/R4/encounter.html) resource and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Encounter when conforming to this profile. It provides the floor for standards development for specific uses cases in a Philippine context."
+* subject only Reference(PHCorePatient)
+* participant.individual only Reference(PHCorePractitioner or PractitionerRole or PHCoreRelatedPerson)


### PR DESCRIPTION
Added constraints to PHCore types in PHCoreEncounter References. 

Note that we don't yet have a PHCoreRelatedPerson; when we do get that, we should update the Encounter Reference to match that.