### PR TITLE
Update: standardize naming conventions to Profile Names with CamelCase

### DIFF
--- a/input/fsh/codeSystems/indigenous-groups.fsh
+++ b/input/fsh/codeSystems/indigenous-groups.fsh
@@ -1,5 +1,5 @@
-CodeSystem: IndigenousGroups
-Id: indigenous-groups
+CodeSystem: IndigenousGroupsCS
+Id: indigenous-groups-cs
 Title: "Indigenous Groups"
 Description: "A list of codes representing the recognized indigenous groups in the Philippines to which a person may belong."
 * insert ShareableCodeSystem

--- a/input/fsh/extensions/indigenous-group.fsh
+++ b/input/fsh/extensions/indigenous-group.fsh
@@ -5,4 +5,4 @@ Title: "Indigenous Group"
 Description: "Indigenous / ethnic group that the patient belongs to."
 * insert ExperimentalStructureDefinition
 * value[x] only CodeableConcept
-* value[x] from indigenous-groups (required)
+* value[x] from IndigenousGroupsVS (required)

--- a/input/fsh/profiles/ph-core-medication.fsh
+++ b/input/fsh/profiles/ph-core-medication.fsh
@@ -4,4 +4,4 @@ Id: ph-core-medication
 Title: "PH Core Medication"
 Description: "This resource is primarily used for the identification and definition of a medication, including ingredients, for the purposes of prescribing, dispensing, and administering a medication as well as for making statements about medication use."
 * insert ExperimentalStructureDefinition
-* code from drugs (extensible)
+* code from DrugsVS (extensible)

--- a/input/fsh/valueSets/drugs.fsh
+++ b/input/fsh/valueSets/drugs.fsh
@@ -1,5 +1,5 @@
-ValueSet: Drugs
-Id: drugs
+ValueSet: DrugsVS
+Id: drugs-vs
 Title: "Drugs"
 Description: "This value set includes all drug or medicament substance codes and all pharmaceutical/biologic products from FDA."
 * insert ShareableValueSet

--- a/input/fsh/valueSets/indigenous-groups.fsh
+++ b/input/fsh/valueSets/indigenous-groups.fsh
@@ -1,6 +1,6 @@
-ValueSet: IndigenousGroups
-Id: indigenous-groups
+ValueSet: IndigenousGroupsVS
+Id: indigenous-groups-vs
 Title: "Indigenous Groups"
 Description: "A value set representing the recognized Indigenous groups to which a person may belong."
 * insert ShareableValueSet
-* include codes from system IndigenousGroups
+* include codes from system IndigenousGroupsCS


### PR DESCRIPTION
## Summary

This PR standardizes naming conventions across all ValueSet and CodeSystem identifiers to use proper CamelCase with suffixes, improving code consistency and linter compatibility.

## Changes

### CodeSystems
- **IndigenousGroups** → **IndigenousGroupsCS** (id: indigenous-groups-cs)

### ValueSets
- **IndigenousGroups** → **IndigenousGroupsVS** (id: indigenous-groups-vs)
- **Drugs** → **DrugsVS** (id: drugs-vs)

### Reference Updates
- Updated extension bindings to use new ValueSet names
- Updated profile bindings (e.g., PHCoreMedication now binds to DrugsVS)

## Benefits

- **Better tooling support** - Suffixes (CS/VS) make resource types explicit
- **Improved linting** - Linters can better link profile names to resources
- **Consistency** - Aligns with FHIR naming best practices
- **Clarity** - Distinguishes CodeSystems from ValueSets at a glance

## Migration Guide

Implementers should update code references:
- Replace `IndigenousGroups` with `IndigenousGroupsCS` / `IndigenousGroupsVS`
- Replace `Drugs` with `DrugsVS`
- Update all ValueSet/CodeSystem bindings accordingly