### PR TITLE
Fix: PHCoreAddress - Add Region and fix cardinality

### DIFF
--- a/input/fsh/profiles/ph-core-address.fsh
+++ b/input/fsh/profiles/ph-core-address.fsh
@@ -3,8 +3,6 @@ Parent: Address
 Id: ph-core-address
 Title: "PH Core Address"
 Description: "An address for the individual."
-* line 0..* MS
-* extension MS
 * extension contains
     Region named region 0..1 and
     Province named province 0..1 and


### PR DESCRIPTION
## Summary

This PR enhances the PHCoreAddress profile with complete Philippine administrative hierarchy support and corrects cardinality constraints for administrative divisions.

## Changes

### New Extension: Region
- Adds Region as the top-level administrative division
- Cardinality: 0..1

### Cardinality Fixes
- province: 0..* to 0..1
- cityMunicipality: 0..* to 0..1
- barangay: 0..* to 0..1

### Must Support Flags
- Added MS flag to line element (0..* MS)
- Added MS flag to extension element

## Administrative Hierarchy

Region (NEW) -> Province -> City/Municipality -> Barangay

## Benefits

- Complete hierarchy - Full Philippine administrative structure support
- Data quality - Single values prevent duplicate/conflicting entries
- Analytics ready - Structured data for geographic analysis
- Validation - Clear cardinality enables better instance validation

## Affected Resources

- PHCorePatient.address
- PHCorePatient.contact.address
- PHCoreRelatedPerson.address
- PHCoreOrganization.address
- PHCoreOrganization.contact.address
- PHCorePractitioner.address
- PHCoreLocation.address

## Related

Closes #145