### PR TITLE
Add: sex & gender extensions and indigenousPeople modified cardinality

### DIFF
--- a/input/fsh/profiles/ph-core-name.fsh
+++ b/input/fsh/profiles/ph-core-name.fsh
@@ -1,0 +1,15 @@
+Profile: PHCoreName
+Id: ph-core-name
+Parent: HumanName
+Title: "PH Core Name"
+Description: "A name of a person in the philippine context."
+
+* given 0..* MS
+* given ^slicing.discriminator.type = #value
+* given ^slicing.discriminator.path = "$this"
+* given ^slicing.rules = #open
+* given contains
+    first 1..* MS and
+    middle 0..* MS
+* family 0..1 MS
+* suffix 0..* MS

--- a/input/fsh/profiles/ph-core-patient.fsh
+++ b/input/fsh/profiles/ph-core-patient.fsh
@@ -6,12 +6,16 @@ Description: "Captures key demographic and administrative information about indi
 * extension contains
     http://hl7.org/fhir/StructureDefinition/patient-nationality|5.2.0 named nationality 0..* and
     http://hl7.org/fhir/StructureDefinition/patient-religion|5.2.0 named religion 0..* and
-    indigenous-group named indigenousGroup 0..* and
-    indigenous-people named indigenousPeople 1..1 and
-    occupation named occupation 0..* and
-    race named race 0..1 and
-    educational-attainment named educationalAttainment 0..1
-    
+    http://hl7.org/fhir/StructureDefinition/individual-genderIdentity|5.2.0 named genderIdentity 0..* and
+    IndigenousGroup named indigenousGroup 0..* and
+    IndigenousPeople named indigenousPeople 0..1 and
+    Occupation named occupation 0..* and
+    Race named race 0..1 and
+    EducationalAttainment named educationalAttainment 0..1 and
+    http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender|5.2.0 named sex 0..*
+* extension[genderIdentity] ^short = "Gender Identity - in compliance with SOGIE Bill"
+* extension[sex] ^short = "Sex assigned at birth - in compliance with SOGIE Bill"
+
 * identifier ^slicing.discriminator.type = #value
 * identifier ^slicing.discriminator.path = "system"
 * identifier ^slicing.rules = #open
@@ -34,7 +38,16 @@ Description: "Captures key demographic and administrative information about indi
 * identifier[PHCorePddRegistration].type.coding.system = "http://terminology.hl7.org/CodeSystem/v2-0203" (exactly)
 * identifier[PHCorePddRegistration].type.coding.code = #NH (exactly)
 
+* address 0..* MS
 * address only ph-core-address
+
+* birthDate 0..1 MS
+* gender 0..1 MS
+* gender ^short = "Administrative Gender - for backward compatibility with existing implementations"
 * maritalStatus from http://hl7.org/fhir/ValueSet/marital-status (required)
+* name 0..1 MS
+* name only PHCoreName
+* telecom 0..* MS
+* contact.name only PHCoreName
 * contact.relationship from http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype (required)
 * contact.address only ph-core-address


### PR DESCRIPTION
## Summary

This PR introduces SOGIE (Sexual Orientation, Gender Identity, and Expression) Law compliance by distinguishing between administrative gender, gender identity, and sex assigned at birth.

## Changes

### New Extensions on Patient

| Extension | Purpose | Cardinality |
|-----------|---------|-------------|
| genderIdentity | Self-identified gender | 0..* |
| sex | Sex assigned at birth (recordedSexOrGender) | 0..* |
| gender | Administrative gender (existing) | 0..1 |

### Terminology Clarification

- **Administrative Gender** (gender) - For system compatibility and administrative purposes
- **Gender Identity** - Self-identified gender
- **Sex** - Biological sex assigned at birth

### Patient Profile Updates

#### Extension Changes
- indigenousPeople: 1..1 to 0..1 (now optional)
- Updated extension references to use CamelCase names

#### Must Support Flags Added
- birthDate (0..1 MS)
- gender (0..1 MS)
- name (0..1 MS) - using PHCoreName
- telecom (0..* MS)
- address (0..* MS) - using PHCoreAddress

## Implementation Notes

Systems must support all three gender/sex fields for full SOGIE compliance:
- genderIdentity extension for self-identified gender
- sex extension for recorded sex at birth
- gender element for backward compatibility

## Policy Alignment

Resolves policy requirements around gender terminology by distinguishing between different concepts of gender and sex used in healthcare contexts.

## Related Issues

- Closes #146 (indigenousPeople cardinality change)
- Closes #147 (Must Support flags)
- Closes #148 (SOGIE extensions)