### PR TITLE
fix: change indigenousPeople cardinality to optional and use CamelCase Profile name Reference

### DIFF
--- a/input/fsh/profiles/ph-core-patient.fsh
+++ b/input/fsh/profiles/ph-core-patient.fsh
@@ -6,8 +6,8 @@ Description: "Captures key demographic and administrative information about indi
 * extension contains
     http://hl7.org/fhir/StructureDefinition/patient-nationality|5.2.0 named nationality 0..* and
     http://hl7.org/fhir/StructureDefinition/patient-religion|5.2.0 named religion 0..* and
-    indigenous-group named indigenousGroup 0..* and
-    indigenous-people named indigenousPeople 0..1 and
+    IndigenousGroup named indigenousGroup 0..* and
+    IndigenousPeople named indigenousPeople 0..1 and
     occupation named occupation 0..* and
     race named race 0..1 and
     educational-attainment named educationalAttainment 0..1


### PR DESCRIPTION
## Summary
This PR fixes the indigenousPeople extension by making it optional instead of required.

## Changes
- Change indigenousPeople extension cardinality from `1..1` to `0..1`
- Update extension references to use CamelCase (`IndigenousGroup`, `IndigenousPeople`)

## Related Issues
Closes: UP-Manila-SILab/ph-core#146

Related to PR #115 previously made by @jgsuess 