### PR TITLE
feat: add Must Support flags to Patient demographic elements

### DIFF
--- a/input/fsh/profiles/ph-core-patient.fsh
+++ b/input/fsh/profiles/ph-core-patient.fsh
@@ -41,7 +41,7 @@ Description: "Captures key demographic and administrative information about indi
 * gender 0..1 MS
 * gender ^short = "Administrative Gender - for backward compatibility with existing implementations"
 * maritalStatus from http://hl7.org/fhir/ValueSet/marital-status (required)
-* name 0..1 MS
+* name 0..* MS
 * name only PHCoreName or HumanName
 * telecom 0..* MS
 * contact.name only PHCoreName or HumanName


### PR DESCRIPTION
## Summary
This PR adds Must Support flags to key Patient demographic elements and constrains name fields to use PHCoreName profile.

## Changes
- Add MS flags to: `birthDate`, `gender`, `name`, `telecom`, `address` based on the utility of previous Use-case IGs. Ideally, MS in this context should be similar to the `Obligation` feature, where it should be populated when available; however, this feature is unavailable in R4
- Add short description for `gender` as Administrative Gender for backward compatibility
- Constrain `name` and `contact.name` to PHCoreName or HumanName (for backward compatibility and international patients)

## Related Issues
Closes: UP-Manila-SILab/ph-core#147