### PR TITLE
Restrict name constraints to PHCoreName only

### DIFF
--- a/input/fsh/profiles/ph-core-patient.fsh
+++ b/input/fsh/profiles/ph-core-patient.fsh
@@ -37,9 +37,9 @@ Description: "Captures key demographic and administrative information about indi
 * gender ^short = "Administrative Gender - for backward compatibility with existing implementations"
 * maritalStatus from http://hl7.org/fhir/ValueSet/marital-status (required)
 * name 0..* MS
-* name only PHCoreName or HumanName
+* name only PHCoreName
 * telecom 0..* MS
-* contact.name only PHCoreName or HumanName
+* contact.name only PHCoreName
 * contact.relationship from http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype (required)
 
 * contact.address MS


### PR DESCRIPTION
### Description

This pull request addresses **[BUG] PHCoreName extensions not consumable because Patient.name is HumanName OR PHCoreName (#167)**.  

In the current implementation, the `Patient.name` element was modeled with an OR constraint (`HumanName OR PHCoreName`). When processed by SUSHI, the tool defaults to the base `HumanName` type, which does not include the `middleName` extension defined in `PHCoreName`. This caused errors when consuming PHCoreName extensions.  

**Resolution:**  
- Reverted the definition of `Patient.name` to be constrained strictly to `PHCoreName`.  
- Removed the `HumanName OR` option to ensure that extensions like `middleName` are recognized and consumable by downstream tooling.  
- Applied the same correction to `contact.name` to maintain consistency.  

This change aligns with guidance from consultation with Sparked, which clarified that “OR” constraints are only permissible for Address, Identifiers, and Observation—not for `HumanName`.

---

### Benefits

- Fixes SUSHI build errors caused by unrecognized `middleName` extension.  
- Ensures PHCoreName extensions are consumable and interoperable.  
- Improves consistency across PH Core profiles by removing unsupported OR constraints.  
---

### Related Issues

- Fixes **Issue #167**: [BUG] PHCoreName extensions not consumable because Patient.name is HumanName OR PHCoreName.  
- Related to **Issue #166** (identified during review).  
- May have implications for PHCoreAddress or Address references, which should be reviewed separately.