### PR TITLE
feat(ruleset): Add CodeableConceptMS RuleSet for consistent MS declarations

### DIFF
--- a/input/fsh/profiles/ph-core-practitionerRole.fsh
+++ b/input/fsh/profiles/ph-core-practitionerRole.fsh
@@ -4,7 +4,7 @@ Id: ph-core-practitionerrole
 Title: "PH Core PractitionerRole"
 Description: "The PH Core Practitioner Role Profile inherits from the [FHIR R4 PractitionerRole resource](https://hl7.org/fhir/R4/practitionerrole.html); refer to it for scope and usage definitions. This profile sets minimum expectations for the PractitionerRole resource to record, search, and fetch basic demographics and administrative information about an individual practitioner role in a Philippine context. It specifies which core elements, extensions, vocabularies, and value sets SHALL be present and constrains how the elements are used. It provides the floor for standards development for Philippine use cases."
 
-* insert CodeableConceptMS
+* insert CodeableConceptMS(code)
 * identifier 0..* MS 
 
 * telecom 0..* MS

--- a/input/fsh/ruleSets/msCodeableConcept.fsh
+++ b/input/fsh/ruleSets/msCodeableConcept.fsh
@@ -1,4 +1,4 @@
-RuleSet: CodeableConceptMS
-* code MS
-* code.coding MS
-* code.text MS
+RuleSet: CodeableConceptMS(path)
+* {path} MS
+* {path}.coding MS
+* {path}.coding.code MS


### PR DESCRIPTION
This PR introduces a reusable `CodeableConceptMS` RuleSet to ensure consistent Must Support (MS) declarations for CodeableConcept elements across PH Core profiles.

## Problem (Issue #198)
Profiles with CodeableConcept elements need consistent Must Support flags on both `coding` (structured) and the element itself. Previously required repetitive declarations.

## Solution
Parameterized RuleSet in `input/fsh/ruleSets/msCodeableConcept.fsh`:

```fsh
RuleSet: CodeableConceptMS(path)
* {path} MS
* {path}.coding MS
* {path}.coding.code MS
```

Usage: `* insert CodeableConceptMS(code)` 

## Changes
- **New:** `msCodeableConcept.fsh` — reusable parameterized RuleSet
- **Modified:** `ph-core-practitionerRole.fsh` — replaced manual MS declarations with RuleSet insertion

## Design Decision
Parameterized approach allows reuse across any CodeableConcept path (e.g., `specialty`, `code`, `type`) without duplicating the RuleSet.

---
**Next Steps:** Apply to other profiles with CodeableConcept elements.