### PR TITLE
refactor(profiles): Add CodeableConceptMS ruleset to existing profiles

### DIFF
--- a/input/fsh/profiles/ph-core-condition.fsh
+++ b/input/fsh/profiles/ph-core-condition.fsh
@@ -22,3 +22,11 @@ Description: "Captures Condition."
 * encounter only Reference(PHCoreEncounter)
 * recorder only Reference(PHCorePractitioner or PHCorePractitionerRole or PHCorePatient or PHCoreRelatedPerson)
 * asserter only Reference(PHCorePractitioner or PHCorePractitionerRole or PHCorePatient or PHCoreRelatedPerson)
+
+* insert CodeableConceptMS(clinicalStatus)
+* insert CodeableConceptMS(verificationStatus)
+* insert CodeableConceptMS(bodySite)
+* insert CodeableConceptMS(stage.summary)
+* insert CodeableConceptMS(stage.type)
+* insert CodeableConceptMS(evidence.code)
+

--- a/input/fsh/profiles/ph-core-encounter.fsh
+++ b/input/fsh/profiles/ph-core-encounter.fsh
@@ -44,3 +44,14 @@ Description: "This profile sets minimum expectations for an Encounter resource t
 * subject only Reference(PHCorePatient or Group)
 
 * type 0..* MS
+
+* insert CodeableConceptMS(serviceType)
+* insert CodeableConceptMS(priority)
+* insert CodeableConceptMS(diagnosis.use)
+* insert CodeableConceptMS(hospitalization.admitSource)
+* insert CodeableConceptMS(hospitalization.reAdmission)
+* insert CodeableConceptMS(hospitalization.dietPreference)
+* insert CodeableConceptMS(hospitalization.specialCourtesy)
+* insert CodeableConceptMS(hospitalization.specialArrangement)
+* insert CodeableConceptMS(location.physicalType)
+

--- a/input/fsh/profiles/ph-core-immunization.fsh
+++ b/input/fsh/profiles/ph-core-immunization.fsh
@@ -5,3 +5,15 @@ Title: "PH Core Immunization"
 Description: "Describes the event of a patient being administered a vaccine or a record of an immunization as reported by a patient, a clinician or another party."
 * patient only Reference(PHCorePatient)
 * encounter only Reference(PHCoreEncounter)
+
+* insert CodeableConceptMS(statusReason)
+* insert CodeableConceptMS(vaccineCode)
+* insert CodeableConceptMS(reportOrigin)
+* insert CodeableConceptMS(site)
+* insert CodeableConceptMS(route)
+* insert CodeableConceptMS(performer.function)
+* insert CodeableConceptMS(reasonCode)
+* insert CodeableConceptMS(subpotentReason)
+* insert CodeableConceptMS(programEligibility)
+* insert CodeableConceptMS(fundingSource)
+* insert CodeableConceptMS(protocolApplied.targetDisease)

--- a/input/fsh/profiles/ph-core-location.fsh
+++ b/input/fsh/profiles/ph-core-location.fsh
@@ -6,3 +6,7 @@ Description: "This profile localizes the FHIR R4 Location resource to the Philip
 * address only PHCoreAddress
 * managingOrganization only Reference(ph-core-organization)
 * partOf only Reference(ph-core-location)
+
+* insert CodeableConceptMS(type)
+* insert CodeableConceptMS(physicalType)
+

--- a/input/fsh/profiles/ph-core-medication.fsh
+++ b/input/fsh/profiles/ph-core-medication.fsh
@@ -5,3 +5,7 @@ Title: "PH Core Medication"
 Description: "This resource is primarily used for the identification and definition of a medication, including ingredients, for the purposes of prescribing, dispensing, and administering a medication as well as for making statements about medication use."
 * insert ExperimentalStructureDefinition
 * code from DrugsVS (preferred)
+
+* insert CodeableConceptMS(code)
+* insert CodeableConceptMS(form)
+* insert CodeableConceptMS(ingredient.itemCodeableConcept)

--- a/input/fsh/profiles/ph-core-medicationadministration.fsh
+++ b/input/fsh/profiles/ph-core-medicationadministration.fsh
@@ -16,3 +16,13 @@ Description: "Captures key FHIR Medication Administration data for the Philippin
 
 // Philippine-specific binding for medication codes
 * medicationCodeableConcept from DrugsVS (preferred)
+
+* insert CodeableConceptMS(statusReason)
+* insert CodeableConceptMS(category)
+* insert CodeableConceptMS(medicationCodeableConcept)
+* insert CodeableConceptMS(performer.function)
+* insert CodeableConceptMS(reasonCode)
+* insert CodeableConceptMS(dosage.site)
+* insert CodeableConceptMS(dosage.route)
+* insert CodeableConceptMS(dosage.method)
+

--- a/input/fsh/profiles/ph-core-medicationdispense.fsh
+++ b/input/fsh/profiles/ph-core-medicationdispense.fsh
@@ -18,3 +18,12 @@ Description: "Captures key FHIR Medication Dispense data for the Philippine cont
 
 // Philippine-specific binding for medication codes
 * medicationCodeableConcept from DrugsVS (preferred)
+
+* insert CodeableConceptMS(statusReasonCodeableConcept)
+* insert CodeableConceptMS(category)
+* insert CodeableConceptMS(medicationCodeableConcept)
+* insert CodeableConceptMS(performer.function)
+* insert CodeableConceptMS(type)
+* insert CodeableConceptMS(substitution.type)
+* insert CodeableConceptMS(substitution.reason)
+

--- a/input/fsh/profiles/ph-core-medicationrequest.fsh
+++ b/input/fsh/profiles/ph-core-medicationrequest.fsh
@@ -18,3 +18,13 @@ Description: "Captures key FHIR Medication Request data for the Philippine conte
 
 // Philippine-specific binding for medication codes
 * medicationCodeableConcept from DrugsVS (preferred)
+
+* insert CodeableConceptMS(statusReason)
+* insert CodeableConceptMS(category)
+* insert CodeableConceptMS(medicationCodeableConcept)
+* insert CodeableConceptMS(performerType)
+* insert CodeableConceptMS(reasonCode)
+* insert CodeableConceptMS(courseOfTherapyType)
+* insert CodeableConceptMS(substitution.allowedCodeableConcept)
+* insert CodeableConceptMS(substitution.reason)
+

--- a/input/fsh/profiles/ph-core-medicationstatement.fsh
+++ b/input/fsh/profiles/ph-core-medicationstatement.fsh
@@ -21,3 +21,9 @@ Description: "Captures key FHIR Medication Statement data for the Philippine con
 
 // BasedOn references to PH Core profiles
 * basedOn only Reference(PHCoreMedicationRequest or CarePlan or ServiceRequest)
+
+* insert CodeableConceptMS(statusReason)
+* insert CodeableConceptMS(category)
+* insert CodeableConceptMS(medicationCodeableConcept)
+* insert CodeableConceptMS(reasonCode)
+

--- a/input/fsh/profiles/ph-core-observation.fsh
+++ b/input/fsh/profiles/ph-core-observation.fsh
@@ -5,3 +5,17 @@ Title: "PH Core Observation"
 Description: "Measurements and simple assertions made about a patient, device or other subject."
 * subject only Reference(ph-core-patient)
 * encounter only Reference(ph-core-encounter)
+
+* insert CodeableConceptMS(category)
+* insert CodeableConceptMS(code)
+* insert CodeableConceptMS(valueCodeableConcept)
+* insert CodeableConceptMS(dataAbsentReason)
+* insert CodeableConceptMS(interpretation)
+* insert CodeableConceptMS(bodySite)
+* insert CodeableConceptMS(method)
+* insert CodeableConceptMS(referenceRange.type)
+* insert CodeableConceptMS(referenceRange.appliesTo)
+* insert CodeableConceptMS(component.code)
+* insert CodeableConceptMS(component.valueCodeableConcept)
+* insert CodeableConceptMS(component.dataAbsentReason)
+* insert CodeableConceptMS(component.interpretation)

--- a/input/fsh/profiles/ph-core-organization.fsh
+++ b/input/fsh/profiles/ph-core-organization.fsh
@@ -31,3 +31,6 @@ Description: "This profile localizes the FHIR R4 Organization resource to the Ph
 * contact.address only PHCoreAddress
 
 * partOf only Reference(PHCoreOrganization)
+
+* insert CodeableConceptMS(type)
+* insert CodeableConceptMS(contact.purpose)

--- a/input/fsh/profiles/ph-core-patient.fsh
+++ b/input/fsh/profiles/ph-core-patient.fsh
@@ -44,3 +44,8 @@ Description: "Captures key demographic and administrative information about indi
 
 * contact.address MS
 * contact.address only PHCoreAddress
+
+* insert CodeableConceptMS(maritalStatus)
+* insert CodeableConceptMS(contact.relationship)
+* insert CodeableConceptMS(communication.language)
+

--- a/input/fsh/profiles/ph-core-practitioner.fsh
+++ b/input/fsh/profiles/ph-core-practitioner.fsh
@@ -6,3 +6,7 @@ Description: "The PH Core Practitioner Profile inherits from the [FHIR R4 Practi
 
 * address MS
 * address only PHCoreAddress
+
+* insert CodeableConceptMS(qualification.code)
+* insert CodeableConceptMS(communication)
+

--- a/input/fsh/profiles/ph-core-provenance.fsh
+++ b/input/fsh/profiles/ph-core-provenance.fsh
@@ -159,6 +159,11 @@ Description: "This profile localizes the FHIR R4 Provenance resource to the Phil
 
 * agent obeys provenance-1
 
+* insert CodeableConceptMS(reason)
+* insert CodeableConceptMS(activity)
+* insert CodeableConceptMS(agent.role)
+
+
 Invariant: provenance-1
 Description: "onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device"
 Severity: #error

--- a/input/fsh/profiles/ph-core-relatedPerson.fsh
+++ b/input/fsh/profiles/ph-core-relatedPerson.fsh
@@ -15,4 +15,8 @@ Description: "This profile localizes the FHIR R4 RelatedPerson resource to the P
 
 * address MS
 * address only PHCoreAddress
+
+* insert CodeableConceptMS(relationship)
+* insert CodeableConceptMS(communication.language)
+
 // TODO: Explicitly cite system url when RelatedPerson is being reviewed

--- a/input/fsh/profiles/ph-core-serviceRequest.fsh
+++ b/input/fsh/profiles/ph-core-serviceRequest.fsh
@@ -23,3 +23,12 @@ Description: "The PH Core ServiceRequest Profile is a Philippine-specific FHIR p
 * status 1..1 MS
 
 * supportingInfo 0..* MS
+
+* insert CodeableConceptMS(code)
+* insert CodeableConceptMS(orderDetail)
+* insert CodeableConceptMS(asNeededCodeableConcept)
+* insert CodeableConceptMS(performerType)
+* insert CodeableConceptMS(locationCode)
+* insert CodeableConceptMS(reasonCode)
+* insert CodeableConceptMS(bodySite)
+

--- a/input/fsh/profiles/ph-core-task.fsh
+++ b/input/fsh/profiles/ph-core-task.fsh
@@ -28,3 +28,14 @@ Description: "This profile localizes the FHIR R4 Task resource to the Philippine
 * location only Reference(PHCoreLocation)
 * restriction.recipient only Reference(PHCorePatient or PHCorePractitioner or PHCorePractitionerRole or PHCoreRelatedPerson or Group or PHCoreOrganization)
 * partOf only Reference(PHCoreTask)
+
+* insert CodeableConceptMS(statusReason)
+* insert CodeableConceptMS(businessStatus)
+* insert CodeableConceptMS(code)
+* insert CodeableConceptMS(performerType)
+* insert CodeableConceptMS(reasonCode)
+* insert CodeableConceptMS(input.type)
+* insert CodeableConceptMS(input.valueCodeableConcept)
+* insert CodeableConceptMS(output.type)
+* insert CodeableConceptMS(output.valueCodeableConcept)
+


### PR DESCRIPTION
## Summary
Updates existing profiles to use the CodeableConceptMS ruleset for consistent Must Support declarations on CodeableConcept elements.

## Changes
- Applied `CodeableConceptMS` ruleset to 17 core profiles
- Flags `Code.coding` and `Code.text` as Must Support consistently
- Affected profiles: Condition, Encounter, Immunization, Location, Medication, MedicationAdministration, MedicationDispense, MedicationRequest, MedicationStatement, Observation, Organization, Patient, Practitioner, Provenance, RelatedPerson, ServiceRequest, Task

## Tool Used
Generated using the `check-codeable-concepts.ts` script from [ph-core-utils](https://github.com/niccoreyes/ph-core-utils)

## Related Issue
Fixes #198

## Checklist
- [x] IG builds locally
- [x] All profiles use a consistent CodeableConceptMS pattern
- [x] Canonical URLs and identifiers unchanged