### PR TITLE
feat(terminology): add PSA classification aliases and CodeSystem metadata

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -1,5 +1,6 @@
 Alias: $sct = http://snomed.info/sct
 Alias: $loinc = http://loinc.org
+Alias: $iso3166 = urn:iso:std:iso:3166
 Alias: $PSA = https://psa.gov.ph/classification
 Alias: $PSCED = https://psa.gov.ph/classification/psced/level
 Alias: $PSGC = https://psa.gov.ph/classification/psgc
@@ -15,4 +16,6 @@ Alias: $allergyintolerance-clinical = http://terminology.hl7.org/CodeSystem/alle
 Alias: $v3-roleCode = http://terminology.hl7.org/CodeSystem/v3-RoleCode
 Alias: $v3-RouteOfAdministration = http://terminology.hl7.org/CodeSystem/v3-RouteOfAdministration
 Alias: $v2-0443 = http://terminology.hl7.org/CodeSystem/v2-0443
+Alias: $v3-Race = http://terminology.hl7.org/ValueSet/v3-Race
 Alias: $request-priority = http://hl7.org/fhir/request-priority
+Alias: $medicationdispense-performer-function = http://terminology.hl7.org/CodeSystem/medicationdispense-performer-function

--- a/input/fsh/codeSystems/drugs.fsh
+++ b/input/fsh/codeSystems/drugs.fsh
@@ -2,7 +2,7 @@ CodeSystem: PHFDACPRCS
 Id: PHFDACPRCS
 Title: "PH FDA Certificate of Product Registration (CPR) CodeSystem"
 Description: "Registered drug products from the Philippine Food and Drug Administration (FDA)"
-* ^url = "https://verification.fda.gov.ph/"
+* ^url = "https://verification.fda.gov.ph"
 * ^version = "2026.03.21.1115"
 * ^status = #active
 * ^experimental = false

--- a/input/fsh/codeSystems/psced.fsh
+++ b/input/fsh/codeSystems/psced.fsh
@@ -3,4 +3,10 @@ Id: PSCED
 Title: "Mock PSCED"
 Description: "Mock of the Philippine Standard Classification of Education."
 * insert ShareableCodeSystem
-* ^content = #not-present
+* ^url = "https://psa.gov.ph/classification/psced/level"
+* ^version = "0.1.0"
+* ^content = #example
+* #C201301 "Elementary Graduate" "Completed elementary education"
+* #C201302 "High School Graduate" "Completed secondary education"
+* #C201303 "College Graduate" "Completed bachelor's degree"
+* #C201304 "Postgraduate" "Completed master's or doctoral degree"

--- a/input/fsh/codeSystems/psgc.fsh
+++ b/input/fsh/codeSystems/psgc.fsh
@@ -3,6 +3,7 @@ Id: PSGC
 Title: "Mock PSGC"
 Description: "Mock of the Philippine Standard Geographic Code."
 * insert ShareableCodeSystem
+* ^url = "https://psa.gov.ph/classification/psgc"
 * #1380100001 "Barangay 1"
 * #1380100000 "City of Caloocan"
 * #1380200000 "City of Las Piñas"

--- a/input/fsh/codeSystems/psoc.fsh
+++ b/input/fsh/codeSystems/psoc.fsh
@@ -3,4 +3,10 @@ Id: PSOC
 Title: "Mock PSOC"
 Description: "Mock of the Philippine Standard Occupational Classification."
 * insert ShareableCodeSystem
-* ^content = #not-present
+* ^url = "https://psa.gov.ph/classification/psoc/unit"
+* ^version = "0.1.0"
+* ^content = #example
+* #111102 "Hospital Administrator" "Manages hospital operations"
+* #111103 "Medical Department Head" "Head of a medical department"
+* #121101 "General Manager" "Manages overall operations of an organization"
+* #211101 "Medical Doctor" "Licensed physician practicing medicine"

--- a/input/fsh/namingSystems/doh-nhfr-code-ns.fsh
+++ b/input/fsh/namingSystems/doh-nhfr-code-ns.fsh
@@ -7,7 +7,7 @@ Description: "Health Facility Code (HFC) from the National Health Facility Regis
 * kind = #identifier
 * status = #draft
 * date = "2025-06-18"
-* jurisdiction.coding = urn:iso:std:iso:3166#PH
+* jurisdiction.coding = urn:iso:std:iso:3166#PH "Philippines (the)"
 * publisher = "Philippines Department of Health"
 * uniqueId.type = #uri
 * uniqueId.value = "http://doh.gov.ph/fhir/Identifier/doh-nhfr-code"

--- a/input/fsh/namingSystems/doh-procedure-id-ns.fsh
+++ b/input/fsh/namingSystems/doh-procedure-id-ns.fsh
@@ -1,0 +1,13 @@
+Instance: DOHProcedureIDNS
+InstanceOf: NamingSystem
+Usage: #definition
+Title: "DOH Procedure Identifier"
+Description: "Identifier system for procedures assigned by the Department of Health (DOH) health facilities."
+* name = "DOHProcedureID"
+* kind = #identifier
+* status = #draft
+* date = "2025-06-01"
+* jurisdiction.coding = urn:iso:std:iso:3166#PH "Philippines (the)"
+* publisher = "Department of Health (DOH)"
+* uniqueId.type = #uri
+* uniqueId.value = "http://doh.gov.ph/fhir/ph-core/NamingSystem/procedure-id"

--- a/input/fsh/namingSystems/philhealth-accreditation-no.fsh
+++ b/input/fsh/namingSystems/philhealth-accreditation-no.fsh
@@ -7,7 +7,7 @@ Description: "The unique number issued by PhilHealth to accredited institutions.
 * kind = #identifier
 * status = #draft
 * date = "2025-06-01"
-* jurisdiction.coding = urn:iso:std:iso:3166#PH
+* jurisdiction.coding = urn:iso:std:iso:3166#PH "Philippines (the)"
 * publisher = "PhilHealth"
 * uniqueId.type = #uri
 * uniqueId.value = "http://nhdr.gov.ph/fhir/Identifier/philhealthaccreditationnumber"

--- a/input/fsh/namingSystems/philhealth-employer-no.fsh
+++ b/input/fsh/namingSystems/philhealth-employer-no.fsh
@@ -7,7 +7,7 @@ Description: "The unique number issued by PhilHealth to employers."
 * kind = #identifier
 * status = #draft
 * date = "2025-06-01"
-* jurisdiction.coding = urn:iso:std:iso:3166#PH
+* jurisdiction.coding = urn:iso:std:iso:3166#PH "Philippines (the)"
 * publisher = "PhilHealth"
 * uniqueId.type = #uri
 * uniqueId.value = "http://nhdr.gov.ph/fhir/Identifier/philhealthemployernumber"

--- a/input/fsh/namingSystems/philhealth-id-ns.fsh
+++ b/input/fsh/namingSystems/philhealth-id-ns.fsh
@@ -7,7 +7,7 @@ Description: "The permanent and unique number issued by PhilHealth to individual
 * kind = #identifier
 * status = #draft
 * date = "2025-06-01"
-* jurisdiction.coding = urn:iso:std:iso:3166#PH
+* jurisdiction.coding = urn:iso:std:iso:3166#PH "Philippines (the)"
 * publisher = "PhilHealth"
 * uniqueId.type = #uri
 * uniqueId.value = "http://philhealth.gov.ph/fhir/Identifier/philhealth-id"

--- a/input/fsh/namingSystems/philhealth-procedure-id-ns.fsh
+++ b/input/fsh/namingSystems/philhealth-procedure-id-ns.fsh
@@ -1,0 +1,13 @@
+Instance: PhilHealthProcedureIDNS
+InstanceOf: NamingSystem
+Usage: #definition
+Title: "PhilHealth Procedure Identifier"
+Description: "Identifier system for procedures assigned by PhilHealth for claims and reimbursement purposes."
+* name = "PhilHealthProcedureID"
+* kind = #identifier
+* status = #draft
+* date = "2025-06-01"
+* jurisdiction.coding = urn:iso:std:iso:3166#PH "Philippines (the)"
+* publisher = "PhilHealth"
+* uniqueId.type = #uri
+* uniqueId.value = "http://philhealth.gov.ph/procedure"

--- a/input/fsh/namingSystems/philsys-id-ns.fsh
+++ b/input/fsh/namingSystems/philsys-id-ns.fsh
@@ -7,7 +7,7 @@ Description: "The National ID Number issued to all Filipino citizens and residen
 * kind = #identifier
 * status = #draft
 * date = "2025-06-13"
-* jurisdiction.coding = urn:iso:std:iso:3166#PH
+* jurisdiction.coding = urn:iso:std:iso:3166#PH "Philippines (the)"
 * publisher = "Philippine National Identification System"
 * uniqueId.type = #uri
 * uniqueId.value = "http://philsys.gov.ph/fhir/Identifier/philsys-id"


### PR DESCRIPTION
## Summary

This PR adds core terminology infrastructure including PSA classification aliases, CodeSystem metadata, and new NamingSystems for procedure identifiers.

## Changes

### Aliases ([aliases.fsh](input/fsh/aliases.fsh))
- Add `$PSA` - Philippine Statistics Authority base URL
- Add `$PSCED` - Philippine Standard Classification of Education
- Add `$PSGC` - Philippine Standard Geographic Code
- Add `$PSOC` - Philippine Standard Occupational Classification
- Add `$v3-Race` alias for HL7 v3 Race ValueSet
- Add `$medicationdispense-performer-function` for performer function codes

### CodeSystems ([codeSystems/](input/fsh/codeSystems/))
- Add explicit URLs and version metadata to PSCED, PSGC, PSOC
- Change content mode from `#not-present` to `#example` with sample codes
- Fix FDA URL trailing slash in drugs.fsh

### NamingSystems ([namingSystems/](input/fsh/namingSystems/))
- Add `DOHProcedureIDNS` - DOH procedure identifier NamingSystem
- Add `PhilHealthProcedureIDNS` - PhilHealth procedure identifier NamingSystem
- Add jurisdiction display name "Philippines (the)" to all existing NamingSystems

## Fixes

- Fixes #226 (IG Publisher errors - CodeSystem URL, aliases)
- Fixes #229 (QA Errors - ISO 3166 display names in NamingSystems)
- Implements strategy from #231 (terminology content mode decisions)

## Related

- Extracted from #227 for easier review
- #233 depends on this PR
- #234 depends on this PR and #233