### PR TITLE
chore(release): Declare version 0.2.0

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,7 +9,7 @@ name: PHCoreImplementationGuide
 title: Draft PH Core Implementation Guide
 description: This implementation guide is provided to support the use of FHIR®© in an Philippines context, and defines the minimum set of constraints on the FHIR resources to create the PH Core profiles. This implementation guide forms the foundation to build future PH Realm FHIR implementation guides and its content will continue to grow to meet the needs of PH implementers.
 status: draft # draft | active | retired | unknown
-version: 0.1.0
+version: 0.2.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2025+
 releaseLabel: ci-build


### PR DESCRIPTION
## Summary

Bumps the IG version from 0.1.0 to 0.2.0 to establish a stable baseline for eReferral development.

## Changes

- Update `sushi-config.yaml` version from `0.1.0` to `0.2.0`

## Context

This release includes all structural updates from PR #207 and prior. Declaring `v0.2.0` provides:
- A clear signal to implementers that PH Core IG is ready for referral initiation
- A stable reference point for downstream systems piloting eReferral exchanges
- Alignment with semantic versioning practices

Closes #208