### PR TITLE
feat: Add PWD Disability Extension to PH Core Patient

### DIFF
--- a/input/fsh/codeSystems/ph-core-disability-type.fsh
+++ b/input/fsh/codeSystems/ph-core-disability-type.fsh
@@ -1,0 +1,19 @@
+// CodeSystem: PHCoreDisabilityTypeCS
+// Description: Code system for types of disability as defined by the Philippine government for PWD registration.
+// TERMINOLOGY: These codes are examples at the moment and should be properly evaluated before strengthening the binding
+
+CodeSystem: PHCoreDisabilityTypeCS
+Id: ph-core-disability-type-cs
+Title: "PH Core Disability Type Code System"
+Description: "Code system for types of disability as defined by the Philippine government for PWD registration."
+* insert ShareableCodeSystem
+
+* #visual "Visual Disability" "Complete or partial loss of sight/visual function."
+* #hearing "Hearing Disability" "Complete or partial loss of hearing/hearing function."
+* #speech "Speech Impairment" "Complete or partial loss of speech or communication function."
+* #physical "Physical/Orthopedic Disability" "Impairment in physical/orthopedic function including locomotor disabilities."
+* #intellectual "Intellectual Disability" "Significant limitations in intellectual functioning and adaptive behavior."
+* #learning "Learning Disability" "Neurological disorders affecting acquisition and use of listening, speaking, reading, writing, reasoning, or mathematical abilities."
+* #psychosocial "Psychosocial Disability" "Mental health conditions and psychosocial impairments."
+* #visual-low-vision "Low Vision" "Significant visual impairment not correctable by standard glasses/contact lenses."
+* #visual-blindness "Blindness" "Complete loss of vision or light perception."

--- a/input/fsh/extensions/ph-core-pwd-disability.fsh
+++ b/input/fsh/extensions/ph-core-pwd-disability.fsh
@@ -1,6 +1,6 @@
 // Extension: PHCorePWDDisability
-// Description: Extension for Person With Disability (PWD) registration information. 
-// Captures PWD ID number, disability type, and ID expiration date.
+// Description: Extension for Person With Disability (PWD) registration information.
+// Captures PWD ID number, disability type, ID expiration date, and issuing LGU.
 
 Extension: PHCorePWDDisability
 Id: ph-core-pwd-disability
@@ -12,7 +12,8 @@ Description: "Extension for Person With Disability (PWD) registration informatio
 * extension contains
     pwdId 0..1 and
     disabilityType 0..* and
-    idExpirationDate 0..1
+    idExpirationDate 0..1 and
+    issuingLGU 0..1
 
 * extension[pwdId] ^short = "PWD ID Number"
 * extension[pwdId] ^definition = "The unique identification number from the PWD ID card issued by the PDAO (Persons with Disability Affairs Office)."
@@ -26,3 +27,8 @@ Description: "Extension for Person With Disability (PWD) registration informatio
 * extension[idExpirationDate] ^short = "PWD ID Expiration Date"
 * extension[idExpirationDate] ^definition = "The expiration date of the PWD ID card. PWD IDs are typically valid for 3 years or 5 years for senior citizens with disability."
 * extension[idExpirationDate].value[x] only date
+
+* extension[issuingLGU] ^short = "Issuing LGU (Barangay)"
+* extension[issuingLGU] ^definition = "The barangay-level Local Government Unit (LGU) that issued the PWD ID, specified using PSGC code. This captures the issuing authority location, which may differ from the patient's current address. Note: This represents the LGU office location; alternative concepts could include PDAO (Persons with Disability Affairs Office) identifier or specific issuing authority if different from the barangay LGU."
+* extension[issuingLGU].value[x] only CodeableConcept
+* extension[issuingLGU].valueCodeableConcept from Barangays (extensible)

--- a/input/fsh/extensions/ph-core-pwd-disability.fsh
+++ b/input/fsh/extensions/ph-core-pwd-disability.fsh
@@ -1,0 +1,28 @@
+// Extension: PHCorePWDDisability
+// Description: Extension for Person With Disability (PWD) registration information. 
+// Captures PWD ID number, disability type, and ID expiration date.
+
+Extension: PHCorePWDDisability
+Id: ph-core-pwd-disability
+Title: "PH Core PWD Disability Registration"
+Context: Patient
+Description: "Extension for Person With Disability (PWD) registration information. Captures PWD ID number, type of disability, and ID expiration date as issued by the PDAO (Persons with Disability Affairs Office)."
+* insert ExperimentalStructureDefinition
+
+* extension contains
+    pwdId 0..1 and
+    disabilityType 0..* and
+    idExpirationDate 0..1
+
+* extension[pwdId] ^short = "PWD ID Number"
+* extension[pwdId] ^definition = "The unique identification number from the PWD ID card issued by the PDAO (Persons with Disability Affairs Office)."
+* extension[pwdId].value[x] only string
+
+* extension[disabilityType] ^short = "Type of Disability"
+* extension[disabilityType] ^definition = "The type/category of disability as classified by the Philippine government. Multiple types may be specified."
+* extension[disabilityType].value[x] only CodeableConcept
+* extension[disabilityType].valueCodeableConcept from PHCoreDisabilityTypeVS (extensible)
+
+* extension[idExpirationDate] ^short = "PWD ID Expiration Date"
+* extension[idExpirationDate] ^definition = "The expiration date of the PWD ID card. PWD IDs are typically valid for 3 years or 5 years for senior citizens with disability."
+* extension[idExpirationDate].value[x] only date

--- a/input/fsh/profiles/ph-core-patient.fsh
+++ b/input/fsh/profiles/ph-core-patient.fsh
@@ -12,7 +12,8 @@ Description: "Captures key demographic and administrative information about indi
     Occupation named occupation 0..* and
     Race named race 0..1 and
     EducationalAttainment named educationalAttainment 0..1 and
-    http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender|5.2.0 named sex 0..*
+    http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender|5.2.0 named sex 0..* and
+    PHCorePWDDisability named pwdDisability 0..1
 * extension[genderIdentity] ^short = "Gender Identity - in compliance with SOGIE Bill"
 * extension[sex] ^short = "Sex assigned at birth - in compliance with SOGIE Bill"
     

--- a/input/fsh/valueSets/ph-core-disability-type.fsh
+++ b/input/fsh/valueSets/ph-core-disability-type.fsh
@@ -1,0 +1,9 @@
+// ValueSet: PHCoreDisabilityTypeVS
+// Description: Value set for types of disability as defined by the Philippine government for PWD registration.
+
+ValueSet: PHCoreDisabilityTypeVS
+Id: ph-core-disability-type-vs
+Title: "PH Core Disability Type Value Set"
+Description: "Value set for types of disability as defined by the Philippine government for PWD registration."
+* insert ShareableValueSet
+* include codes from system PHCoreDisabilityTypeCS


### PR DESCRIPTION
## Summary

Adopts the PWD (Persons with Disabilities) Disability Extension mechanism from PH E Referral into PH Core. This allows downstream projects to inherit the PWD extension from PH Core instead of redefining it locally, ensuring standardization across Philippine FHIR implementations.

## Related Issues

Closes #239

Related tickets for context:
- **Reference Implementation:** [PH E Referral PR #24](https://github.com/ph-ereferral-organization/ph-ereferral/pull/24) - Original PWD extension implementation in eReferral
- **Related PH Core Issue:** #88 - [TWG] Include extension for PWD (Persons with Disabilities) registration status

## Type of Work

- [x] Profile
- [x] Extension
- [x] CodeSystem
- [x] ValueSet
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] Test Script
- [ ] PH-Core Dependency Change
- [ ] CI/Build Infrastructure
- [ ] Other

## Changes Made

### New Files Created

| File | Description |
|------|-------------|
| `input/fsh/extensions/ph-core-pwd-disability.fsh` | Extension definition with 4 elements: pwdId, disabilityType, idExpirationDate, issuingLGU |
| `input/fsh/codeSystems/ph-core-disability-type.fsh` | CodeSystem with 9 disability type codes |
| `input/fsh/valueSets/ph-core-disability-type.fsh` | ValueSet including all codes from CodeSystem |

### Modified Files

| File | Description |
|------|-------------|
| `input/fsh/profiles/ph-core-patient.fsh` | Added PHCorePWDDisability extension to Patient profile |

### Extension Structure: PHCorePWDDisability

| Element | Cardinality | Type | Description |
|---------|-------------|------|-------------|
| `pwdId` | 0..1 | string | PWD ID Number from PDAO |
| `disabilityType` | 0..* | CodeableConcept | Type of disability (bound to PHCoreDisabilityTypeVS) |
| `idExpirationDate` | 0..1 | date | PWD ID validity period |
| `issuingLGU` | 0..1 | CodeableConcept | Issuing LGU (barangay-level PSGC code) |

### issuingLGU Element

The `issuingLGU` element captures the barangay-level Local Government Unit that issued the PWD ID, using Philippine Standard Geographic Codes (PSGC). This is important because:
- The issuing LGU may differ from the patient's current address
- Enables tracking of which PDAO/LGU office processed the registration
- Supports reporting and analytics by issuance location

**Binding:** Barangays ValueSet (extensible) - includes all barangay-level PSGC codes

### Terminology

**CodeSystem: PHCoreDisabilityTypeCS**
- Codes: visual, hearing, speech, physical, intellectual, learning, psychosocial, visual-low-vision, visual-blindness
- Note: These codes are examples at the moment and should be properly evaluated before strengthening the binding

**ValueSet: PHCoreDisabilityTypeVS**
- Includes all codes from PHCoreDisabilityTypeCS

**ValueSet: Barangays**
- Barangay-level PSGC codes for issuing LGU location
- PSGC = Philippine Standard Geographic Codes published by PSA

## Validation / Testing

- [x] IG builds successfully (`sushi .` passes with 0 errors, 0 warnings)
- [ ] Examples validate
- [ ] Terminology checked
- [ ] Links verified
- [ ] Other:

### SUSHI Results
```
Profiles: 26 | Extensions: 10 | Logicals: 0 | Resources: 0
ValueSets: 9 | CodeSystems: 6 | Instances: 38
0 Errors, 0 Warnings
```

## Reviewer Notes

Please verify:
- Extension naming follows PH Core conventions (`ph-core-pwd-disability`)
- CodeSystem and ValueSet naming follows conventions (`PHCoreDisabilityTypeCS`, `PHCoreDisabilityTypeVS`)
- Extension is properly added to PHCorePatient profile
- Terminology codes are appropriate for Philippine PWD registration context
- Canonical URLs are correct (`http://doh.gov.ph/fhir/ph-core`)
- issuingLGU binding to Barangays ValueSet is appropriate (extensible)

## Preview / Screenshots

**Auto-built IG Preview:** https://build.fhir.org/ig/niccoreyes/ph-core/branches/feat-pwd-disability-extension/

Use this link to preview the rendered Implementation Guide with the new PWD extension.

## Benefits of Core-Level Adoption

1. **Standardization**: Ensures consistent PWD data capture across all Philippine FHIR implementations
2. **Reusability**: Downstream projects can inherit from PH Core instead of redefining
3. **Interoperability**: Common PWD identifiers enable better tracking of disability services nationwide
4. **Alignment**: Matches PDAO registration requirements
5. **Location Tracking**: issuingLGU enables tracking of issuance location separate from patient address

## Future State for Downstream Projects

Once this is in PH Core, projects like PH E Referral can simply:
```fsh
* extension contains PHCorePWDDisability named disabilityRegistration 0..1
```
Instead of defining their own extension.