### PR TITLE
Update PH Core Patient to reference PH Core profiles (#274)

### DIFF
--- a/input/fsh/profiles/ph-core-patient.fsh
+++ b/input/fsh/profiles/ph-core-patient.fsh
@@ -58,19 +58,8 @@ Description: "Captures key demographic and administrative information about indi
 * insert CodeableConceptSO(communication.language)
 
 // PH Core Profile References - Issue #274
-* generalPractitioner 0..* MS
-* generalPractitioner insert ObligationOptional
 * generalPractitioner only Reference(PHCorePractitioner or PHCorePractitionerRole or PHCoreOrganization)
-
-* managingOrganization 0..1 MS
-* managingOrganization insert ObligationOptional
 * managingOrganization only Reference(PHCoreOrganization)
-
-* link.other 1..1 MS
-* link.other insert ObligationOptional
 * link.other only Reference(PHCorePatient or PHCoreRelatedPerson)
-
-* contact.organization 0..1 MS
-* contact.organization insert ObligationOptional
 * contact.organization only Reference(PHCoreOrganization)
 

--- a/input/fsh/profiles/ph-core-patient.fsh
+++ b/input/fsh/profiles/ph-core-patient.fsh
@@ -57,3 +57,20 @@ Description: "Captures key demographic and administrative information about indi
 * insert CodeableConceptSO(contact.relationship)
 * insert CodeableConceptSO(communication.language)
 
+// PH Core Profile References - Issue #274
+* generalPractitioner 0..* MS
+* generalPractitioner insert ObligationOptional
+* generalPractitioner only Reference(PHCorePractitioner or PHCorePractitionerRole or PHCoreOrganization)
+
+* managingOrganization 0..1 MS
+* managingOrganization insert ObligationOptional
+* managingOrganization only Reference(PHCoreOrganization)
+
+* link.other 1..1 MS
+* link.other insert ObligationOptional
+* link.other only Reference(PHCorePatient or PHCoreRelatedPerson)
+
+* contact.organization 0..1 MS
+* contact.organization insert ObligationOptional
+* contact.organization only Reference(PHCoreOrganization)
+


### PR DESCRIPTION
## Summary

Updates the PH Core Patient profile to reference available PH Core profiles instead of base FHIR resources. This ensures all internal references within the IG point to PH Core-constrained resources, improving consistency and enabling proper validation.

## Related Issue

Closes #274

## Type of Work

- [x] Profile
- [ ] Extension
- [ ] CodeSystem
- [ ] ValueSet
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] Documentation
- [ ] Test Script
- [ ] CI/Build Infrastructure
- [ ] Other

## Changes Made

Updated the following Patient elements to reference PH Core profiles (following the Profile Reference Hierarchy from #272):

| Element | Before (Base FHIR) | After (PH Core Profiles) |
|---------|-------------------|--------------------------|
| `generalPractitioner` | Organization \| Practitioner \| PractitionerRole | PHCorePractitioner \| PHCorePractitionerRole \| PHCoreOrganization |
| `managingOrganization` | Organization | PHCoreOrganization |
| `link.other` | Patient \| RelatedPerson | PHCorePatient \| PHCoreRelatedPerson |
| `contact.organization` | Organization | PHCoreOrganization |

**Key points:**
- All references now exclusively use PH Core profiles (no base FHIR fallbacks)
- Self-reference enabled for `link.other` (PHCorePatient can reference PHCorePatient)
- Aligns with patterns established in other PH Core profiles (e.g., PHCorePractitionerRole)

## Validation / Testing

- [x] IG builds successfully (`sushi .` with 0 errors)
- [ ] Examples validate
- [ ] Terminology checked
- [ ] Links verified
- [ ] Other:

**SUSHI Results:**
```
Converted 35 FHIR StructureDefinitions
Exported 99 FHIR resources as JSON
0 Errors      0 Warnings
```

## Reviewer Notes

- Please verify that the reference constraints align with intended PH Core profile usage
- Check that all referenced PH Core profiles (PHCorePractitioner, PHCorePractitionerRole, PHCoreOrganization, PHCoreRelatedPerson) are appropriate for their respective elements
- No breaking changes expected - this is a constraint tightening that should improve data quality

## Preview / Screenshots

Build preview: https://build.fhir.org/ig/niccoreyes/ph-core/branches/feat-patient-profile-references-274/StructureDefinition-ph-core-patient.html