### PR TITLE
[T] Migrate from fhir.base.template to fhir2.base.template (Security Update)

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,3 +1,3 @@
 [IG]
 ig = fsh-generated/resources/ImplementationGuide-fhir.ph.core.json
-template = fhir.base.template#current
+template = fhir2.base.template#current


### PR DESCRIPTION
## Summary

Security update to migrate from the insecure `fhir.base.template` to the new secure `fhir2.base.template` as per HL7 security notice issued March 17, 2026.

HL7 identified a supply chain security vulnerability in the FHIR ecosystem where the `fhir.base.template` package was flagged as insecure and blocked on npmjs.com due to potential dependency confusion attacks.

## Related Issue

Closes #261

## Type of Work

- [ ] Profile
- [ ] Extension
- [ ] CodeSystem
- [ ] ValueSet
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] Documentation
- [ ] Test Script
- [x] CI/Build Infrastructure
- [ ] Other

## Changes Made

Updated `ig.ini` configuration file:
- Changed `template` property from `fhir.base.template#current` to `fhir2.base.template#current`

This single-line change ensures compliance with HL7 security standards and prevents potential supply chain attacks. The IG Publisher will soon refuse to run for IGs that still depend on `fhir.base.template`.

## Validation / Testing

- [ ] IG builds successfully (`sushi .` with 0 errors)
- [ ] Examples validate
- [ ] Terminology checked
- [ ] Links verified
- [x] Other: Configuration file syntax verified

## Reviewer Notes

This is a high-priority security update. The change is minimal and follows HL7's security advisory recommendations. No FSH resources, profiles, or other IG content were modified.

Reference: https://www.fhir.org/guides/security-notices/2026-03-npm-dependencies.html

## Preview / Screenshots

N/A - This is a build infrastructure change affecting the IG template dependency only.