### PR TITLE
[FR-U] Update PHCoreLocation Profile per PH Core Heuristic (#277)

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -30,3 +30,4 @@ Alias: $consumer = http://doh.gov.ph/fhir/ph-core/ActorDefinition/Consumer
 Alias: $creator = http://doh.gov.ph/fhir/ph-core/ActorDefinition/Creator
 Alias: $v3-Race = http://terminology.hl7.org/ValueSet/v3-Race
 Alias: $medicationdispense-performer-function = http://terminology.hl7.org/CodeSystem/medicationdispense-performer-function
+Alias: $location-physical-type = http://terminology.hl7.org/CodeSystem/location-physical-type

--- a/input/fsh/examples/location-single-example.fsh
+++ b/input/fsh/examples/location-single-example.fsh
@@ -1,7 +1,7 @@
 Instance: location-single-example
 InstanceOf: PHCoreLocation
 Usage: #example
-Description: "Philippine General Hospital Main Building - A tertiary hospital located in Manila."
+Description: "Philippine General Hospital Main Building - A tertiary hospital located in Manila with geographic coordinates and physical type."
 * status = #active
 * name = "Philippine General Hospital"
 * address.line = "Taft Avenue"
@@ -10,5 +10,9 @@ Description: "Philippine General Hospital Main Building - A tertiary hospital lo
 * address.postalCode = "1000"
 * address.country = "PH"
 * type = $v3-roleCode#HOSP "Hospital"
+* managingOrganization = Reference(organization-single-example)
+* physicalType = $location-physical-type#bu "Building"
+* position.longitude = 120.9856
+* position.latitude = 14.5764
 * text.status = #generated
 * text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Philippine General Hospital Main Building - A tertiary hospital located in Manila.</div>"

--- a/input/fsh/profiles/ph-core-location.fsh
+++ b/input/fsh/profiles/ph-core-location.fsh
@@ -15,11 +15,11 @@ Description: "This profile localizes the FHIR R4 Location resource to the Philip
 // Must Support Elements with Obligations
 // ============================================
 
-// Status - Optional
+// Status
 * status MS
 * status insert ObligationOptional
 
-// Name - Optional
+// Name
 * name MS
 * name insert ObligationOptional
 
@@ -42,7 +42,7 @@ Description: "This profile localizes the FHIR R4 Location resource to the Philip
 * position.latitude insert ObligationOptional
 
 // ============================================
-// CodeableConcept Elements (SO = Optional)
+// CodeableConcept Elements
 // ============================================
 * insert CodeableConceptSO(type)
 * insert CodeableConceptSO(physicalType)

--- a/input/fsh/profiles/ph-core-location.fsh
+++ b/input/fsh/profiles/ph-core-location.fsh
@@ -3,10 +3,46 @@ Parent: Location
 Id: ph-core-location
 Title: "PH Core Location"
 Description: "This profile localizes the FHIR R4 Location resource to the Philippine context."
-* address only PHCoreAddress
-* managingOrganization only Reference(ph-core-organization)
-* partOf only Reference(ph-core-location)
 
+// ============================================
+// PH Core Specific References
+// ============================================
+* address only PHCoreAddress
+* managingOrganization only Reference(PHCoreOrganization)
+* partOf only Reference(PHCoreLocation)
+
+// ============================================
+// Must Support Elements with Obligations
+// ============================================
+
+// Status - Optional
+* status MS
+* status insert ObligationOptional
+
+// Name - Required
+* name MS
+* name insert ObligationRequired
+
+// Address and sub-elements
+* address MS
+* address insert ObligationOptional
+* address.line MS
+* address.line insert ObligationOptional
+
+// Managing Organization
+* managingOrganization MS
+* managingOrganization insert ObligationOptional
+
+// Position and sub-elements
+* position MS
+* position insert ObligationOptional
+* position.longitude MS
+* position.longitude insert ObligationRequired
+* position.latitude MS
+* position.latitude insert ObligationRequired
+
+// ============================================
+// CodeableConcept Elements (SO = Optional)
+// ============================================
 * insert CodeableConceptSO(type)
 * insert CodeableConceptSO(physicalType)
-

--- a/input/fsh/profiles/ph-core-location.fsh
+++ b/input/fsh/profiles/ph-core-location.fsh
@@ -19,9 +19,9 @@ Description: "This profile localizes the FHIR R4 Location resource to the Philip
 * status MS
 * status insert ObligationOptional
 
-// Name - Required
+// Name - Optional
 * name MS
-* name insert ObligationRequired
+* name insert ObligationOptional
 
 // Address and sub-elements
 * address MS
@@ -37,9 +37,9 @@ Description: "This profile localizes the FHIR R4 Location resource to the Philip
 * position MS
 * position insert ObligationOptional
 * position.longitude MS
-* position.longitude insert ObligationRequired
+* position.longitude insert ObligationOptional
 * position.latitude MS
-* position.latitude insert ObligationRequired
+* position.latitude insert ObligationOptional
 
 // ============================================
 // CodeableConcept Elements (SO = Optional)


### PR DESCRIPTION
## Summary

Updated the `PHCoreLocation` profile to align with the PH Core heuristic pattern as specified in issue #277. This includes fixing profile reference names, adding Must Support (MS) markers, and implementing obligation rules for key elements.

## Related Issue

Closes #277
Related to #275 (Parent: Update Profiles per PH Core Heuristic)

## Type of Work

- [x] Profile
- [ ] Extension
- [ ] CodeSystem
- [ ] ValueSet
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] Documentation
- [ ] Test Script
- [ ] CI/Build Infrastructure
- [ ] Other

## Changes Made

### 1. Fixed Reference Profile Names
- `ph-core-organization` → `PHCoreOrganization` (proper profile name casing)
- `ph-core-location` → `PHCoreLocation` (self-reference with proper casing)

### 2. Added Must Support (MS) Markers and Obligations

| Element | MS | Obligation | Notes |
|---------|-----|------------|-------|
| `status` | ✓ | ObligationOptional | Per PH Core Patient pattern |
| `name` | ✓ | ObligationOptional | Changed from ObligationRequired for consistency |
| `address` | ✓ | ObligationOptional | Already in profile, added MS |
| `address.line` | ✓ | ObligationOptional | From Road Safety IG pattern |
| `managingOrganization` | ✓ | ObligationOptional | Per issue requirements |
| `position` | ✓ | ObligationOptional | From Road Safety IG pattern |
| `position.longitude` | ✓ | ObligationOptional | Changed from ObligationRequired for consistency |
| `position.latitude` | ✓ | ObligationOptional | Changed from ObligationRequired for consistency |
| `type` | ✓ | ObligationOptional | Via `CodeableConceptSO` RuleSet |
| `physicalType` | ✓ | ObligationOptional | Via `CodeableConceptSO` RuleSet |

### 3. Profile Structure Improvements
- Organized with clear section comments (PH Core Specific References, Must Support Elements, CodeableConcept Elements)
- Removed redundant "Optional" suffixes from comments (implied by ObligationOptional)
- No explicit cardinality declarations per PH Core convention
- Follows self-referencing pattern for hierarchical Location structures

### 4. Enhanced Example
- Added `managingOrganization` reference to organization-single-example
- Added `physicalType` (Building)
- Added `position.longitude` and `position.latitude` with PGH coordinates
- Added `$location-physical-type` alias for terminology

## Obligation Pattern Note

All Must Support elements now use `ObligationOptional` to maintain consistency with:
- **PHCorePatient** - uses ObligationOptional throughout
- **PHCoreOrganization** - uses only MS flags (consistent approach)

This removes the previously specified required obligations on name and GPS coordinates, making the profile more flexible for various location types (facilities, floors, wings) that may not always have complete data.

## Validation / Testing

- [x] IG builds successfully (`sushi .` with 0 errors)
- [x] Examples validate
- [ ] Terminology checked
- [ ] Links verified
- [ ] Other:

**SUSHI Results:**
```
| Just like a perfect pearl.             0 Errors      0 Warnings |
| Profiles: 26 | Extensions: 9 | ValueSets: 8 | CodeSystems: 5 | Instances: 52 |
```

## Reviewer Notes

- All obligation assignments now align with PH Core Heuristic (all Optional to match PHCorePatient pattern)
- Profile reference naming follows convention (PHCoreXxx not ph-core-xxx)
- Position coordinates are now optional, accommodating locations without precise GPS data
- Note: type and physicalType use the CodeableConceptSO RuleSet which applies ObligationOptional

## Preview / Screenshots

Preview available at: https://build.fhir.org/ig/niccoreyes/ph-core/branches/feat-277-update-location-profile/