### PR TITLE
[FR-U] Align Procedure and ServiceRequest examples (#327)

### DIFF
--- a/input/fsh/examples/procedure-single-example.fsh
+++ b/input/fsh/examples/procedure-single-example.fsh
@@ -61,6 +61,3 @@ Description: "A comprehensive example of an appendectomy procedure performed on 
 
 * usedCode = $sct#261424001 "Primary operation"
 * usedCode.text = "Laparoscopic instruments"
-
-* text.status = #generated
-* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Procedure:</b> Laparoscopic appendectomy (SNOMED CT: 80146002)</p><p><b>Subject:</b> Juan Dela Cruz</p><p><b>Status:</b> Completed</p><p><b>Performed:</b> January 15, 2024, 08:30 - 10:15 (Asia/Manila)</p><p><b>Performer:</b> Dr. Maria Clara Santos (Healthcare professional) on behalf of Department of Health - Central Office</p><p><b>Reason:</b> Acute appendicitis with peritonitis (SNOMED CT: 74400008)</p><p><b>Body Site:</b> Entire appendix - Right lower quadrant abdomen</p><p><b>Outcome:</b> Successful - Procedure completed without complications</p><p><b>Follow-up:</b> Postsurgical wound care in 7 days</p><p><b>Notes:</b> Patient tolerated procedure well. Minimal blood loss. Appendix was inflamed but intact.</p></div>"

--- a/input/fsh/examples/servicerequest-single-example.fsh
+++ b/input/fsh/examples/servicerequest-single-example.fsh
@@ -6,11 +6,10 @@ Description: "A laboratory service request for fasting blood glucose test ordere
 * intent = #order
 * category = $sct#108252007 "Laboratory procedure"
 * code = $sct#33747003 "Glucose measurement, blood"
+* code.text = "Fasting blood glucose test"
 * subject = Reference(Patient/patient-single-example)
 * encounter = Reference(Encounter/encounter-single-example)
 * authoredOn = "2024-03-15T09:30:00+08:00"
 * occurrenceDateTime = "2024-03-15T10:00:00+08:00"
 * requester = Reference(Practitioner/practitioner-single-example)
 * supportingInfo = Reference(Condition/condition-single-example)
-* text.status = #generated
-* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">A laboratory service request for fasting blood glucose test ordered by Dr. Maria Clara Santos for patient Juan Dela Cruz during an ambulatory encounter.</div>"


### PR DESCRIPTION
## Summary

Aligns the PH Core Procedure and ServiceRequest examples for #327 by removing hardcoded narrative and verifying that both examples reference the canonical single examples.

## Related Issue

Closes #327
Parent: #305

## Type of Work

- [ ] Profile
- [ ] Extension
- [ ] CodeSystem
- [ ] ValueSet
- [ ] ConceptMap
- [x] Example
- [ ] Narrative Page
- [ ] Documentation
- [ ] Test Script
- [ ] CI/Build Infrastructure
- [ ] Other

## Changes Made

- Removed hardcoded `text.status` and `text.div` from `procedure-single-example`.
- Removed hardcoded `text.status` and `text.div` from `servicerequest-single-example`.
- Added `code.text = "Fasting blood glucose test"` to `servicerequest-single-example`.
- Verified `procedure-single-example` remains `InstanceOf: PHCoreProcedure`.
- Verified `servicerequest-single-example` remains `InstanceOf: PHCoreServiceRequest`.
- Verified Procedure references:
  - `Patient/patient-single-example`
  - `Encounter/encounter-single-example`
  - `Practitioner/practitioner-single-example`
  - `Condition/condition-single-example`
  - `RelatedPerson/relatedperson-single-example`
  - `Organization/organization-single-example`
- Verified ServiceRequest references:
  - `Patient/patient-single-example`
  - `Encounter/encounter-single-example`
  - `Practitioner/practitioner-single-example`
  - `Condition/condition-single-example`

## Validation / Testing

- [ ] IG builds successfully (`sushi .` with 0 errors)
- [ ] Examples validate
- [x] Terminology checked
- [ ] Links verified
- [x] Other: Generated SUSHI output was inspected for the targeted Procedure and ServiceRequest resources.

Validation note:

`git diff --check` passed.

`sushi.cmd .` was attempted, but the local run failed on existing unrelated obligation RuleSet and practitioner extension path errors. The generated output still confirmed that `Procedure-procedure-single-example.json` uses the PH Core Procedure profile, `ServiceRequest-servicerequest-single-example.json` uses the PH Core ServiceRequest profile, both resources reference the expected canonical single examples, and neither resource contains top-level hardcoded narrative.

## Reviewer Notes

This PR intentionally keeps scope limited to Procedure and ServiceRequest example alignment for #327. It does not remove hardcoded narratives from unrelated examples because those are covered by separate example-alignment sub-issues under #305.

## Preview / Screenshots

Fork branch preview:
https://build.fhir.org/ig/jldalisay95/ph-core-jld/tree/issue-327-procedure-servicerequest-examples-alignment