### PR TITLE
[PRIO] [T] Replace global inline CSS with class-based scoped styling via fragment-css.html override

### DIFF
--- a/input/fsh/examples/location-single-example.fsh
+++ b/input/fsh/examples/location-single-example.fsh
@@ -4,7 +4,7 @@ Usage: #example
 Title: "Example PH Core Location"
 Description: "Philippine General Hospital - A government tertiary hospital located in Manila, Philippines."
 * text.status = #generated
-* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Philippine General Hospital (PGH) is an active tertiary government hospital located in Ermita, City of Manila, National Capital Region, Philippines.</div>"
+* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Philippine General Hospital (PGH) is an active tertiary government hospital located in Ermita, City of Manila, National Capital Region (NCR), Philippines.</div>"
 * status = #active
 * name = "Philippine General Hospital"
 * type.coding = $v3-roleCode#HOSP "Hospital"

--- a/input/fsh/examples/organization-pgh-example.fsh
+++ b/input/fsh/examples/organization-pgh-example.fsh
@@ -34,7 +34,7 @@ Description: "Philippine General Hospital (PGH) — A government tertiary hospit
 * address.postalCode = "1000"
 * address.country = "PH"
 
-* address.extension[region].valueCoding = $PSGC#1300000000 "National Capital Region"
+* address.extension[region].valueCoding = $PSGC#1300000000 "National Capital Region (NCR)"
 * address.extension[cityMunicipality].valueCoding = $PSGC#1380600000 "City of Manila"
 * address.extension[barangay].valueCoding = $PSGC#1339000003 "Ermita"
 
@@ -46,6 +46,6 @@ Description: "Philippine General Hospital (PGH) — A government tertiary hospit
 * contact.address.city = "Manila"
 * contact.address.postalCode = "1000"
 * contact.address.country = "PH"
-* contact.address.extension[region].valueCoding = $PSGC#1300000000 "National Capital Region"
+* contact.address.extension[region].valueCoding = $PSGC#1300000000 "National Capital Region (NCR)"
 * contact.address.extension[cityMunicipality].valueCoding = $PSGC#1380600000 "City of Manila"
 * contact.address.extension[barangay].valueCoding = $PSGC#1339000003 "Ermita"

--- a/input/fsh/examples/patient-acs-example.fsh
+++ b/input/fsh/examples/patient-acs-example.fsh
@@ -47,7 +47,7 @@ Description: "Juan Dela Cruz, 45-year-old Filipino male, residing in City of Las
 * address.country = "PH"
 
 * address.extension[cityMunicipality].valueCoding = $PSGC#1380200000 "City of Las Piñas"
-* address.extension[region].valueCoding = $PSGC#1300000000 "National Capital Region"
+* address.extension[region].valueCoding = $PSGC#1300000000 "National Capital Region (NCR)"
 
 * generalPractitioner = Reference(Practitioner/practitioner-ed-example)
 * managingOrganization = Reference(Organization/organization-pgh-example)

--- a/input/fsh/examples/practitioner-ed-example.fsh
+++ b/input/fsh/examples/practitioner-ed-example.fsh
@@ -27,7 +27,7 @@ Description: "Dr. Maria Clara Santos, MD — Emergency Medicine Attending Physic
 
 * address.extension[barangay].valueCoding = $PSGC#1339000003 "Ermita"
 * address.extension[cityMunicipality].valueCoding = $PSGC#1380600000 "City of Manila"
-* address.extension[region].valueCoding = $PSGC#1300000000 "National Capital Region"
+* address.extension[region].valueCoding = $PSGC#1300000000 "National Capital Region (NCR)"
 
 * gender = #female
 * birthDate = "1985-05-15"

--- a/input/includes/fragment-css.html
+++ b/input/includes/fragment-css.html
@@ -1,0 +1,48 @@
+<style>
+.ph-table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1em 0;
+  font-size: 0.95em;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+
+.ph-table thead {
+  display: table-header-group;
+}
+
+.ph-table th {
+  background-color: #555555;
+  color: #ffffff;
+  font-weight: 600;
+  padding: 10px 14px;
+  text-align: left;
+  border: 1px solid #444444;
+}
+
+.ph-table td {
+  padding: 8px 14px;
+  border: 1px solid #e2e8f0;
+  vertical-align: top;
+}
+
+.ph-table tbody tr:nth-child(odd) {
+  background-color: #ffffff;
+}
+
+.ph-table tbody tr:nth-child(even) {
+  background-color: #f7fafc;
+}
+
+.ph-table tbody tr:hover {
+  background-color: #ebf8ff;
+  transition: background-color 0.2s ease;
+}
+
+.ph-table td code {
+  background-color: #edf2f7;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+</style>

--- a/input/includes/fragment-css.html
+++ b/input/includes/fragment-css.html
@@ -1,4 +1,9 @@
 <style>
+.ph-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 .ph-table {
   border-collapse: collapse;
   width: 100%;

--- a/input/pagecontent/StructureDefinition-ph-core-patient-intro.md
+++ b/input/pagecontent/StructureDefinition-ph-core-patient-intro.md
@@ -36,6 +36,7 @@ When only partial age information is known, set `birthDate` according to the fol
 | Only year known | `YYYY` | Age = 2 years old → `2024` |
 | Month and year known | `YYYY-MM` | Age = 6 months old → `2025-09` |
 | Full date known | `YYYY-MM-DD` | Age = 10 days old → `2026-03-09` |
+{:.ph-table}
 
 #### Back-Calculation for Display
 
@@ -61,4 +62,5 @@ When deriving `birthDate` from age, systems should assume the earliest possible 
 | 2-year-old child | "2 years old" | `2024` | Year only; display as "2024 (approximate)" |
 | 6-month-old infant | "6 months old" | `2025-09` | Month and year; display as "September 2025 (approximate)" |
 | 10-day-old newborn | "10 days old" | `2026-03-09` | Full date known |
+{:.ph-table}
 

--- a/input/pagecontent/StructureDefinition-ph-core-provenance-intro.md
+++ b/input/pagecontent/StructureDefinition-ph-core-provenance-intro.md
@@ -28,6 +28,7 @@ The PH Core Provenance Profile inherits from the FHIR Provenance resource; refer
 | `agent.who` | PHCorePractitioner, PHCorePractitionerRole, PHCoreOrganization, PHCorePatient, PHCoreRelatedPerson | Device |
 | `agent.onBehalfOf` | PHCoreOrganization | - |
 | `location` | PHCoreLocation | - |
+{:.ph-table}
 
 ## Profile Specific Implementation Guidance
 
@@ -39,6 +40,7 @@ The `agent` element is sliced to distinguish between authors and transmitters:
 |-------|------|---------|
 | `ProvenanceAuthor` | author | Entity that created the data |
 | `ProvenanceTransmitter` | transmitter | Entity that transmitted the data |
+{:.ph-table}
 
 ### Constraint: provenance-1
 
@@ -60,6 +62,7 @@ This Provenance profile can be used with the following resource types:
 | [PHCorePatient](StructureDefinition-ph-core-patient.html) |
 | [PHCoreProcedure](StructureDefinition-ph-core-procedure.html) |
 | [PHCoreRelatedPerson](StructureDefinition-ph-core-relatedperson.html) |
+{:.ph-table}
 
 ### Base FHIR Resources
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,10 +1,3 @@
-<style>
-img, svg {
-  max-width: 100%;
-  height: auto !important;
-  box-sizing: border-box;
-}
-</style>
 
 # Draft Philippine Core FHIR Implementation Guide (PH Core IG)
 

--- a/input/pagecontent/otherIds.md
+++ b/input/pagecontent/otherIds.md
@@ -10,6 +10,7 @@
 | PPN | Passport Number | Patient.identifier |
 | EN | PEN - PhilHealth Employer Number | Organization.identifier |
 | AN | PAN - Accreditation Number | Organization.identifier |
+{:.ph-table}
 
 ---
 
@@ -21,6 +22,7 @@
 | SB | SSS / GSIS |
 | DL | Driver's License |
 | PPN | Passport Number |
+{:.ph-table}
 
 ## Organization ID's:
 
@@ -28,6 +30,7 @@
 |:---------|:------------|
 | EN | PEN - PhilHealth Employer's Number |
 | AN | PAN - Accreditation Number |
+{:.ph-table}
 
 
 ```

--- a/input/pagecontent/sample-case.md
+++ b/input/pagecontent/sample-case.md
@@ -7,73 +7,6 @@ This tutorial walks you through a complete emergency department case using **FHI
 **Test Server:** `https://cdr.fhirlab.net/fhir`  
 **Server Capability:** Supports FHIR R4, all CRUD operations, transaction Bundles
 
-<style>
-  /* Table styling for sample-case page */
-  .markdown-body table,
-  table {
-    border-collapse: collapse;
-    width: 100%;
-    margin: 1em 0;
-    font-size: 0.95em;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  }
-
-  .markdown-body table thead,
-  table thead {
-    display: table-header-group;
-  }
-
-  .markdown-body table th,
-  table th {
-    background-color: #2c5282;
-    color: #ffffff;
-    font-weight: 600;
-    padding: 12px 16px;
-    text-align: left;
-    border: 1px solid #1a365d;
-  }
-
-  .markdown-body table td,
-  table td {
-    padding: 10px 16px;
-    border: 1px solid #e2e8f0;
-    vertical-align: top;
-  }
-
-  .markdown-body table tbody tr:nth-child(odd),
-  table tbody tr:nth-child(odd) {
-    background-color: #ffffff;
-  }
-
-  .markdown-body table tbody tr:nth-child(even),
-  table tbody tr:nth-child(even) {
-    background-color: #f7fafc;
-  }
-
-  .markdown-body table tbody tr:hover,
-  table tbody tr:hover {
-    background-color: #ebf8ff;
-    transition: background-color 0.2s ease;
-  }
-
-  /* Style for code within tables */
-  .markdown-body table td code,
-  table td code {
-    background-color: #edf2f7;
-    padding: 2px 6px;
-    border-radius: 3px;
-    font-size: 0.9em;
-    color: #2d3748;
-  }
-
-  /* Style for the first column (often headers/labels) */
-  .markdown-body table td:first-child,
-  table td:first-child {
-    font-weight: 500;
-    color: #2d3748;
-  }
-</style>
-
 ---
 
 ## Table of Contents
@@ -109,12 +42,13 @@ This tutorial walks you through a complete emergency department case using **FHI
 | **Reference** | A link pointing to another resource | `Patient/patient-acs-example` |
 | **Profile** | Extra rules on top of base FHIR | PH Core adds Philippine-specific requirements |
 | **REST API** | Standard HTTP methods (GET, POST, PUT, DELETE) | `GET https://server/fhir/Patient/123` |
+{:.ph-table}
 
 ### Anatomy of a FHIR Resource
 
 Every FHIR resource is a JSON object with these key parts:
 
-```json
+```jsonc
 {
   "resourceType": "Patient",          // ⭐ What kind of resource is this?
   "id": "patient-acs-example",        // Unique identifier (you choose or server assigns)
@@ -150,6 +84,7 @@ https://cdr.fhirlab.net/fhir/{resourceType}/{id}
 | **PUT** | Replace data | Update/replace entire resource | `PUT /Patient/123` |
 | **PATCH** | Modify data | Partial update | `PATCH /Patient/123` |
 | **DELETE** | Remove data | Delete a resource | `DELETE /Patient/123` |
+{:.ph-table}
 
 ### Required Headers
 
@@ -173,6 +108,7 @@ The following table provides a framework recommendation for choosing the right H
 | **GET** | **Read / Search** | Used to retrieve a specific resource by ID or search for multiple resources matching criteria. A successful request returns a `200 OK`. | Any resource (e.g., `Patient`, `Condition`, `Encounter`) |
 | **DELETE** | **Delete** | Used to remove a resource from the server. Successful deletion returns a `204 No Content`. Previous versions may remain accessible via history. | Any Resource |
 | **PATCH** | **Partial Update** | Used to apply **partial modifications** to a resource without sending the entire body. | `Patient` |
+{:.ph-table}
 
 ### Key Discussion and Best Practices
 
@@ -211,6 +147,7 @@ When processing multiple resources simultaneously (like a patient, their device,
 | **DELETE** | ✅ Yes | Deleting the same resource twice results in the same deleted state. |
 | **POST** | ❌ No | Posting the same resource multiple times will create **duplicate records** with different IDs. |
 | **PATCH** | ❌ No | Patching the same resource multiple times may produce different results depending on the starting state. |
+{:.ph-table}
 
 > **Important:** Because POST is not idempotent, you must design your client carefully. If a POST request times out, you cannot safely retry it without risk of duplicates. For registry resources, prefer Conditional PUT to avoid this problem.
 
@@ -230,7 +167,7 @@ FHIR uses the **JSON Patch** format (`Content-Type: application/json-patch+json`
 >
 > **Request Body:**
 >
-> ```json
+> ```jsonc
 > [
 >   {
 >     "op": "replace",
@@ -357,6 +294,7 @@ Accept: application/fhir+json
 | Observation | `code` | `?code=85354-9` |
 | Condition | `subject` | `?subject=Patient/123` |
 | Condition | `code` | `?code=401303003` |
+{:.ph-table}
 
 ---
 
@@ -380,7 +318,7 @@ Accept: application/fhir+json
 
 #### Request Body
 
-```json
+```jsonc
 {
   "resourceType": "Patient",
   "meta": {
@@ -434,7 +372,7 @@ Accept: application/fhir+json
           "valueCoding": {
             "system": "https://psa.gov.ph/classification/psgc",
             "code": "1300000000",
-            "display": "National Capital Region"
+            "display": "National Capital Region (NCR)"
           }
         }
       ]
@@ -539,6 +477,7 @@ Accept: application/fhir+json
 | `birthDate` | ⭐ Yes | ISO date (YYYY-MM-DD) | `"1981-03-15"` |
 | `address` | No | Home address | With PSGC extensions for Philippines |
 | `extension` | 🇵🇭 PH Core | PH-specific data | nationality, religion, education, occupation |
+{:.ph-table}
 
 #### Expected Response
 
@@ -576,7 +515,7 @@ Accept: application/fhir+json
 
 #### Request Body
 
-```json
+```jsonc
 {
   "resourceType": "Encounter",
   "meta": {
@@ -671,6 +610,7 @@ Accept: application/fhir+json
 | `serviceProvider` | No | Which organization? | Reference to Organization |
 | `participant` | No | Who was involved? | Practitioner references |
 | `hospitalization` | No | Admission details | Where did the patient come from? |
+{:.ph-table}
 
 > **Important:** The `subject.reference` must use the **server-assigned ID** from the Patient POST response. If the server assigned `123`, use `Patient/123`.
 
@@ -690,7 +630,7 @@ Accept: application/fhir+json
 
 #### Request Body
 
-```json
+```jsonc
 {
   "resourceType": "Condition",
   "meta": {
@@ -767,6 +707,7 @@ Accept: application/fhir+json
 | `encounter` | No | Which visit? | `Encounter/456` |
 | `onsetDateTime` | No | When did it start? | `"2026-06-12T08:30:00+08:00"` |
 | `recordedDate` | No | When was it documented? | `"2026-06-12T08:45:00+08:00"` |
+{:.ph-table}
 
 ---
 
@@ -786,7 +727,7 @@ Accept: application/fhir+json
 
 #### Request Body
 
-```json
+```jsonc
 {
   "resourceType": "Observation",
   "meta": {
@@ -906,6 +847,7 @@ Accept: application/fhir+json
 | `component` | No | For complex measurements | Systolic + Diastolic |
 | `valueQuantity` | No | The numeric result | `value: 160`, `unit: "mmHg"` |
 | `interpretation` | No | High, Low, Normal | `"H"` = High |
+{:.ph-table}
 
 #### Why `component`?
 
@@ -941,7 +883,7 @@ Accept: application/fhir+json
 
 Change the `address` field:
 
-```json
+```jsonc
 {
   "resourceType": "Patient",
   "id": "123",                          // ⭐ Must include the ID
@@ -977,7 +919,7 @@ Change the `address` field:
           "valueCoding": {
             "system": "https://psa.gov.ph/classification/psgc",
             "code": "1300000000",
-            "display": "National Capital Region"
+            "display": "National Capital Region (NCR)"
           }
         }
       ]
@@ -1055,7 +997,7 @@ Accept: application/fhir+json
 
 #### Request Body (JSON Patch)
 
-```json
+```jsonc
 [
   {
     "op": "replace",
@@ -1072,6 +1014,7 @@ Accept: application/fhir+json
 | `add` | Adds a new field | `{"op": "add", "path": "/telecom/1", "value": {...}}` |
 | `replace` | Changes an existing field | `{"op": "replace", "path": "/gender", "value": "male"}` |
 | `remove` | Deletes a field | `{"op": "remove", "path": "/telecom/1"}` |
+{:.ph-table}
 
 #### Concrete JSON Patch Example
 
@@ -1085,7 +1028,7 @@ Accept: application/fhir+json
 
 **Request Body:**
 
-```json
+```jsonc
 [
   {
     "op": "replace",
@@ -1194,7 +1137,7 @@ Accept: application/fhir+json
 
 ### Request Body
 
-```json
+```jsonc
 {
   "resourceType": "Bundle",
   "id": "bundle-acs-case-example",
@@ -1255,7 +1198,7 @@ Accept: application/fhir+json
                 "valueCoding": {
                   "system": "https://psa.gov.ph/classification/psgc",
                   "code": "1300000000",
-                  "display": "National Capital Region"
+                  "display": "National Capital Region (NCR)"
                 }
               }
             ]
@@ -1539,6 +1482,7 @@ Accept: application/fhir+json
 | `request.method` | HTTP method | `POST` for each entry |
 | `request.url` | Resource type | `Patient`, `Encounter`, `Condition`, `Observation` |
 | References | Cross-linking | `Condition.subject` points to `urn:uuid:patient-acs-example` |
+{:.ph-table}
 
 ### Expected Response
 
@@ -1790,6 +1734,7 @@ curl -X GET \
 | **PATCH** | `/Patient/123` | JSON Patch | Update specific fields |
 | **DELETE** | `/Patient/123` | None | Remove a resource |
 | **POST** | `/` | Bundle | Create multiple resources atomically |
+{:.ph-table}
 
 ### Framework Quick Reference
 
@@ -1801,6 +1746,7 @@ curl -X GET \
 | Updating only one field | **PATCH** with JSON Patch |
 | Reading or searching | **GET** |
 | Removing data | **DELETE** |
+{:.ph-table}
 
 ### Critical Rules
 
@@ -1823,6 +1769,7 @@ curl -X GET \
 | Nationality | `extension` | `http://hl7.org/fhir/StructureDefinition/patient-nationality` |
 | Religion | `extension` | `http://hl7.org/fhir/StructureDefinition/patient-religion` |
 | Occupation | `extension` | `https://fhir.doh.gov.ph/phcore/StructureDefinition/occupation` |
+{:.ph-table}
 
 ### Next Steps
 

--- a/input/pagecontent/sample-case.md
+++ b/input/pagecontent/sample-case.md
@@ -101,6 +101,8 @@ Accept: application/fhir+json
 
 The following table provides a framework recommendation for choosing the right HTTP method based on the FHIR interaction and resource type. This guidance helps prevent common mistakes like duplicate records or overwriting clinical history.
 
+<div class="ph-scroll" markdown="1">
+
 | REST Method | FHIR Interaction | Resource Recommendation & Best Practice | Key Resource Examples |
 | :--- | :--- | :--- | :--- |
 | **POST** | **Create** | Used when the **server assigns the logical ID**. Recommended for clinical events where each submission is a new measurement. Also used to submit **Transactions** to the server root. | `Observation` (new vitals), `Bundle` (Transactions), `Patient` (new record) |
@@ -109,6 +111,8 @@ The following table provides a framework recommendation for choosing the right H
 | **DELETE** | **Delete** | Used to remove a resource from the server. Successful deletion returns a `204 No Content`. Previous versions may remain accessible via history. | Any Resource |
 | **PATCH** | **Partial Update** | Used to apply **partial modifications** to a resource without sending the entire body. | `Patient` |
 {:.ph-table}
+
+</div>
 
 ### Key Discussion and Best Practices
 


### PR DESCRIPTION
Fixes #355

## Summary

Replaced the global inline `<style>` block in `sample-case.md` with a controlled, class-based approach using Kramdown Inline Attribute List syntax (`{:.ph-table}`). Removed element-level `img, svg` style from `index.md` in favor of element-level inline attributes.

## Changes

| File | Change |
|------|--------|
| `input/includes/fragment-css.html` | **Created** — overrides template's empty `fragment-css.html` placeholder; provides `.ph-table` visual class and `.ph-scroll` overflow utility |
| `input/pagecontent/sample-case.md` | Removed 65-line global `<style>` block; added `{:.ph-table}` to 14 tables; wrapped the wide REST Methods table in `<div class=\"ph-scroll\" markdown=\"1\">`; changed ```json` → ```jsonc` (10 blocks) |
| `input/pagecontent/index.md` | Removed `img, svg { max-width: 100% }` inline `<style>` block — ecosystem diagram already has `style=\"width: 100%; height: auto;\"` inline; SVG banner uses `width=\"100%\"` on the element itself |
| `input/pagecontent/otherIds.md` | Added `{:.ph-table}` to 3 tables |
| `input/pagecontent/StructureDefinition-ph-core-patient-intro.md` | Added `{:.ph-table}` to 2 tables |
| `input/pagecontent/StructureDefinition-ph-core-provenance-intro.md` | Added `{:.ph-table}` to 3 tables |

## Key design decisions

- **Header color** `#555555` matches the template's existing `.table th.inverted` pattern (`project.css:583`).
- **Removed** `td:first-child { font-weight: 500 }` — too opinionated, would break profile table layouts.
- **CSS loading** uses the IG Publisher's documented `fragment-css.html` override mechanism (`fragment-pagebegin.html:29`).
- **No global element selectors** — only `.ph-table` and `.ph-scroll` class-based rules.
- **Auto-generated profile tables** (snapshots, differentials, terminology) are completely unaffected.
- **No `display: block` on tables** — `.ph-scroll` is a wrapper `<div>` using native `overflow-x: auto`, preserving table semantics.
- **Conditional scroll** — `overflow-x: auto` only shows a scrollbar when content exceeds the container width.

## Research references

The approach is informed by established FHIR IG patterns:

1. **US Core (`HL7/US-Core`)** — Uses Kramdown inline attribute lists (`{:.stu-note}`) for class-based block styling; zero `<style>` blocks in pagecontent.
2. **AU Base (`hl7au/au-fhir-base`)** — No inline styles; relies on template defaults for all table rendering.
3. **PH eReferral (`ph-ereferral-organization/ph-ereferral`)** — Same SVG DRAFT banner pattern; no table-level `<style>` overrides.
4. **Kenya Patient Summary FHIR IG (`IntelliSOFT-Consulting/Kenya-Patient-Summary-FHIR-IG`)** — Documents `css-extras = input/includes/custom.css` in `ig.ini`, confirming the template-fragment approach as the intended extension point.
5. **Template `fhir2.base.template#current`** — `fragment-pagebegin.html:29` calls `{% include fragment-css.html %}`. Overriding this file in `input/includes/` is the documented mechanism for custom CSS injection.
6. **Template `project.css` (line 583-587)** — Already defines `.table th.inverted { background-color: #555555; color: #ffffff }` — our header color derives from this design token.
7. **Template `fhir.css`** — Provides scoped table classes (`.grid`, `.codes`, `.list`, `.dict`, `.colsn`) for profile snapshots. Our `{:.ph-table}` mirrors this class-based pattern.

## Build verification

```
sushi . && java -jar input-cache/publisher.jar -ig . -tx n/a
Errors: 0, Warnings: 300, Info: 1400, Broken Links: 0
```

All 22 `class=\"ph-table\"` applications verified in rendered HTML across 4 pages. Zero unintended styling on profile/terminology pages. No leftover `img, svg` element-level selectors in output.

## Additional changes (second commit)

Cosmetic alignment of PSGC region display names across FSH examples. This does **not** fix the underlying CodeSystem validation errors — the publisher still cannot resolve PSGC/PSCED/PSOC codes in offline mode. It only ensures the display label matches the official PSGC CodeSystem fragment definition.

| File | PSGC Code | Before | After |
|------|-----------|--------|-------|
| `location-single-example.fsh` | N/A (narrative text) | `National Capital Region` | `National Capital Region (NCR)` |
| `organization-pgh-example.fsh` | `1300000000` | `National Capital Region` (2x) | `National Capital Region (NCR)` (2x) |
| `patient-acs-example.fsh` | `1300000000` | `National Capital Region` | `National Capital Region (NCR)` |
| `practitioner-ed-example.fsh` | `1300000000` | `National Capital Region` | `National Capital Region (NCR)` |